### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "nightly"
+  - "3.5.0b3"
 # command to install dependencies
 install:
     - "pip install pyflakes"


### PR DESCRIPTION
"nightly" Python version currently fails on travis. Fixing version number to 3.5.0b3 (available according to http://docs.travis-ci.com/user/languages/python/ ).