### PR TITLE
Add Python 3.2, 3.3 and 3.4 to the travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 python:
+  - "3.2"
+  - "3.3"
+  - "3.4"
   - "3.5.0b3"
 # command to install dependencies
 install:


### PR DESCRIPTION
3.2 currently fails to install the typing backport, but it's nice to know, what works and what doesn't.