### PR TITLE
Change no the new container based travis infrastructure an add python…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,30 @@ language: python
 python:
   - "3.3"
   - "3.4"
-#  - "3.5.0b3"
+  - "3.5"
+
+#use container based infrastructure
+sudo: false
+
+#these directories are persistent
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.cache/miniconda3_pkgs
+    - $HOME/Downloads
+
 # Setup anaconda
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+# install miniconda with symlink of pkg dir to cache
+  - chmod +x ./install_miniconda3.sh
+  - ./install_miniconda3.sh
+#
+  - export PATH=$HOME/miniconda3/bin:$PATH
   - conda update --yes conda
-  # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
-  - sudo rm -rf /dev/shm
-  - sudo ln -s /run/shm /dev/shm
-# Install packages
-install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib
+  - pip install pyflakes coverage coveralls
+install:
   - python setup.py install
-  - "pip install pyflakes"
-  - "pip install coverage"
-  - "pip install coveralls"
 script:
   - "coverage run --source=src --rcfile=coverage.ini setup.py test"
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 #
   - export PATH=$HOME/miniconda3/bin:$PATH
   - conda update --yes conda
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip atlas numpy scipy matplotlib
   - pip install pyflakes coverage coveralls
 install:
   - python setup.py install

--- a/install_miniconda3.sh
+++ b/install_miniconda3.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+if [ ! -d "$HOME/Downloads" ]; then
+  mkdir $HOME/Downloads
+fi
+
+if [ ! -e "$HOME/Downloads/miniconda3.sh" ]; then
+  wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $HOME/Downloads/miniconda3.sh
+  chmod +x $HOME/Downloads/miniconda3.sh
+else
+  echo 'Using cached miniconda installer.';
+fi
+
+$HOME/Downloads/miniconda3.sh -b
+
+rm -r -f $HOME/miniconda3/pkgs
+ln -s $HOME/.cache/miniconda3_pkgs $HOME/miniconda3/pkgs
+
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 import sys
 
 if sys.version_info < (3, 5):
-    requires_typing = ['typing==3.5.0b1']
+    requires_typing = ['typing==3.5.0']
 else:
     requires_typing = []
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 from setuptools import setup
 import sys
 
+if sys.version_info < (3, 3):
+    sys.stderr.write('ERROR: You need Python 3.3 or later '
+                     'to install the qctoolkit package.\n')
+    exit(1)
+
 if sys.version_info < (3, 5):
     requires_typing = ['typing==3.5.0']
 else:


### PR DESCRIPTION
… 3.5 as travis enviroment.

The new infrastructure supports caching which gives us roughly one minute.
Python 3.5 is now included in miniconda, so we can use it: https://www.continuum.io/blog/developer/python-35-support-anaconda