### PR TITLE
Issues/145 foor loop duration

### DIFF
--- a/qctoolkit/pulses/function_pulse_template.py
+++ b/qctoolkit/pulses/function_pulse_template.py
@@ -126,8 +126,8 @@ class FunctionPulseTemplate(AtomicPulseTemplate, MeasurementDefiner, ParameterCo
 
     def get_serialization_data(self, serializer: Serializer) -> Dict[str, Any]:
         return dict(
-            duration_expression=serializer.dictify(self.__duration_expression),
-            expression=serializer.dictify(self.__expression),
+            duration_expression=self.__duration_expression,
+            expression=self.__expression,
             channel=self.__channel,
             measurement_declarations=self.measurement_declarations,
             parameter_constraints=[str(c) for c in self.parameter_constraints]
@@ -135,15 +135,15 @@ class FunctionPulseTemplate(AtomicPulseTemplate, MeasurementDefiner, ParameterCo
 
     @staticmethod
     def deserialize(serializer: Serializer,
-                    expression: str,
-                    duration_expression: str,
+                    expression: Any,
+                    duration_expression: Any,
                     channel: 'ChannelID',
                     measurement_declarations: List[MeasurementDeclaration],
                     parameter_constraints: List,
                     identifier: Optional[bool]=None) -> 'FunctionPulseTemplate':
         return FunctionPulseTemplate(
-            serializer.deserialize(expression),
-            serializer.deserialize(duration_expression),
+            expression,
+            duration_expression,
             channel=channel,
             identifier=identifier,
             measurements=measurement_declarations,

--- a/qctoolkit/pulses/parameters.py
+++ b/qctoolkit/pulses/parameters.py
@@ -15,7 +15,7 @@ from numbers import Real
 import sympy
 import numpy
 
-from qctoolkit.serialization import Serializable, Serializer, ExtendedJSONEncoder
+from qctoolkit.serialization import Serializable, Serializer, AnonymousSerializable
 from qctoolkit.expressions import Expression
 from qctoolkit.comparable import Comparable
 
@@ -150,7 +150,7 @@ class MappedParameter(Parameter):
         return MappedParameter(serializer.deserialize(expression))
 
 
-class ParameterConstraint(Comparable):
+class ParameterConstraint(Comparable, AnonymousSerializable):
     """A parameter constraint like 't_2 < 2.7' that can be used to set bounds to parameters."""
     def __init__(self, relation: Union[str, sympy.Expr]):
         super().__init__()
@@ -187,7 +187,9 @@ class ParameterConstraint(Comparable):
                                    self._expression.sympified_expression.rhs)
         else:
             return str(self._expression.sympified_expression)
-ExtendedJSONEncoder.str_constructable_types.add(ParameterConstraint)
+
+    def get_serialization_data(self) -> str:
+        return str(self)
 
 
 class ParameterConstrainer:

--- a/qctoolkit/pulses/repetition_pulse_template.py
+++ b/qctoolkit/pulses/repetition_pulse_template.py
@@ -126,7 +126,7 @@ class RepetitionPulseTemplate(LoopPulseTemplate, ParameterConstrainer):
 
     @property
     def duration(self) -> Expression:
-        return Expression(self.repetition_count.sympified_expression * self.body.duration.sympified_expression)
+        return self.repetition_count * self.body.duration
 
     def build_sequence(self,
                        sequencer: Sequencer,

--- a/qctoolkit/pulses/sequence_pulse_template.py
+++ b/qctoolkit/pulses/sequence_pulse_template.py
@@ -176,7 +176,7 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer):
 
     @property
     def duration(self) -> Expression:
-        return Expression(sum(sub.duration.sympified_expression for sub in self.__subtemplates))
+        return sum(sub.duration for sub in self.__subtemplates)
 
     @property
     def defined_channels(self) -> Set[ChannelID]:

--- a/qctoolkit/pulses/table_pulse_template.py
+++ b/qctoolkit/pulses/table_pulse_template.py
@@ -317,9 +317,10 @@ class TablePulseTemplate(AtomicPulseTemplate, ParameterConstrainer, MeasurementD
 
     @property
     def duration(self) -> Expression:
-        return Expression('Max({})'.format(','.join(
-            (str(entries[-1].t) for entries in self._entries.values())
-        )))
+        duration_expressions = [entries[-1].t for entries in self._entries.values()]
+        duration_expression = sympy.Max(*(expr.sympified_expression for expr in duration_expressions))
+        return Expression(duration_expression,
+                          numpy_evaluation=all(expr.numpy_evaluation for expr in duration_expressions))
 
     @property
     def defined_channels(self) -> Set[ChannelID]:

--- a/tests/expression_tests.py
+++ b/tests/expression_tests.py
@@ -215,6 +215,14 @@ class ExpressionTests(unittest.TestCase):
         self.assertIsInstance(flt, float)
         self.assertEqual(flt, 3.)
 
+        st = Expression('a + b').get_most_simple_representation()
+        self.assertIsInstance(st, str)
+        self.assertEqual(st, 'a + b')
+
+        st_n = Expression('a+b', numpy_evaluation=False).get_most_simple_representation()
+        self.assertIsInstance(st_n, Expression)
+        self.assertEqual(st_n, 'a+b')
+
     def test_is_nan(self):
         self.assertTrue(Expression('nan').is_nan())
         self.assertTrue(Expression('0./0.').is_nan())

--- a/tests/expression_tests.py
+++ b/tests/expression_tests.py
@@ -1,7 +1,7 @@
 import unittest
 
 import numpy as np
-from sympy import sympify
+from sympy import sympify, Eq
 
 from qctoolkit.expressions import Expression, ExpressionVariableMissingException, NonNumericEvaluation
 from qctoolkit.serialization import Serializer
@@ -22,7 +22,6 @@ class ExpressionTests(unittest.TestCase):
             e.evaluate_numeric(**params)
 
     def test_evaluate_numpy(self):
-        self
         e = Expression('a * b + c')
         params = {
             'a': 2*np.ones(4),
@@ -30,6 +29,38 @@ class ExpressionTests(unittest.TestCase):
             'c': -7*np.ones(4)
         }
         np.testing.assert_equal((2 * 1.5 - 7) * np.ones(4), e.evaluate_numeric(**params))
+
+    def test_evaluate_numeric_without_numpy(self):
+        e = Expression('a * b + c', numpy_evaluation=False)
+
+        params = {
+            'a': 2,
+            'b': 1.5,
+            'c': -7
+        }
+        self.assertEqual(2 * 1.5 - 7, e.evaluate_numeric(**params))
+
+        params = {
+            'a': 2j,
+            'b': 1.5,
+            'c': -7
+        }
+        self.assertEqual(2j * 1.5 - 7, e.evaluate_numeric(**params))
+
+        params = {
+            'a': 2,
+            'b': 6,
+            'c': -7
+        }
+        self.assertEqual(2 * 6 - 7, e.evaluate_numeric(**params))
+
+        params = {
+            'a': 2,
+            'b': sympify('k'),
+            'c': -7
+        }
+        with self.assertRaises(NonNumericEvaluation):
+            e.evaluate_numeric(**params)
 
     def test_evaluate_symbolic(self):
         e = Expression('a * b + c')
@@ -58,7 +89,7 @@ class ExpressionTests(unittest.TestCase):
     def test_repr(self):
         s = 'a    *    b'
         e = Expression(s)
-        self.assertEqual('Expression(a    *    b)', repr(e))
+        self.assertEqual("Expression('a    *    b')", repr(e))
 
     def test_str(self):
         s = 'a    *    b'
@@ -140,6 +171,36 @@ class ExpressionTests(unittest.TestCase):
         self.assertIs(3 > valued, True)
         self.assertIs(3 <= valued, False)
         self.assertIs(3 >= valued, True)
+
+    def assertExpressionEqual(self, lhs: Expression, rhs: Expression):
+        self.assertTrue(bool(Eq(lhs.sympified_expression, rhs.sympified_expression)), '{} and {} are not equal'.format(lhs, rhs))
+
+    def test_number_math(self):
+        a = Expression('a')
+        b = 3.3
+
+        self.assertExpressionEqual(a + b, b + a)
+        self.assertExpressionEqual(a - b, -(b - a))
+        self.assertExpressionEqual(a * b, b * a)
+        self.assertExpressionEqual(a / b, 1 / (b / a))
+
+    def test_symbolic_math(self):
+        a = Expression('a')
+        b = Expression('b')
+
+        self.assertExpressionEqual(a + b, b + a)
+        self.assertExpressionEqual(a - b, -(b - a))
+        self.assertExpressionEqual(a * b, b * a)
+        self.assertExpressionEqual(a / b, 1 / (b / a))
+
+    def test_sympy_math(self):
+        a = Expression('a')
+        b = sympify('b')
+
+        self.assertExpressionEqual(a + b, b + a)
+        self.assertExpressionEqual(a - b, -(b - a))
+        self.assertExpressionEqual(a * b, b * a)
+        self.assertExpressionEqual(a / b, 1 / (b / a))
 
     def test_get_most_simple_representation(self):
         cpl = Expression('1 + 1j').get_most_simple_representation()

--- a/tests/pulses/loop_pulse_template_tests.py
+++ b/tests/pulses/loop_pulse_template_tests.py
@@ -124,10 +124,22 @@ class ForLoopPulseTemplateTest(unittest.TestCase):
         self.assertIs(loop_index, flt.loop_index)
 
     def test_duration(self):
-        dt = DummyPulseTemplate(parameter_names={'i', 'k'}, duration=Expression('d'))
-        flt = ForLoopPulseTemplate(body=dt, loop_index='i', loop_range=(3, 9, 2))
+        dt = DummyPulseTemplate(parameter_names={'idx', 'd'}, duration=Expression('d+idx*2'))
 
-        self.assertEqual(flt.duration, Expression('d*3'))
+        flt = ForLoopPulseTemplate(body=dt, loop_index='idx', loop_range='n')
+        self.assertEqual(flt.duration.evaluate_numeric(n=4, d=100), 4 * 100 + 2 * (1 + 2 + 3))
+
+        flt = ForLoopPulseTemplate(body=dt, loop_index='idx', loop_range=(3, 'n', 2))
+        self.assertEqual(flt.duration.evaluate_numeric(n=9, d=100), 3*100 + 2*(3 + 5 + 7))
+        self.assertEqual(flt.duration.evaluate_numeric(n=8, d=100), 3 * 100 + 2 * (3 + 5 + 7))
+
+        flt = ForLoopPulseTemplate(body=dt, loop_index='idx', loop_range=('m', 'n', -2))
+        self.assertEqual(flt.duration.evaluate_numeric(n=9, d=100, m=14),
+                         3 * 100 + 2 * (14 + 12 + 10))
+
+        flt = ForLoopPulseTemplate(body=dt, loop_index='idx', loop_range=('m', 'n', -2))
+        self.assertEqual(flt.duration.evaluate_numeric(n=9, d=100, m=14),
+                         3 * 100 + 2*(14 + 12 + 10))
 
     def test_parameter_names(self):
         dt = DummyPulseTemplate(parameter_names={'i', 'k'})


### PR DESCRIPTION
Fix bug #145 by using sympy.Sum for duration calculation.

sympy.Sum does not like the default lambdify/numpy evaluation of Expressions. I had to implement a flag to turn this of and a method to propagate that flag easily. This was done by adding basic math methods to the ```Expression``` class.
