### PR TITLE
add convenience function to convert expression to float

### DIFF
--- a/qctoolkit/expressions.py
+++ b/qctoolkit/expressions.py
@@ -74,6 +74,10 @@ class Expression(AnonymousSerializable, metaclass=_ExpressionMeta):
         result = self.expression_lambda(**parsed_kwargs)
         return self._parse_evaluate_numeric_result(result, kwargs)
 
+    def __float__(self):
+        e = self.evaluate_numeric()
+        return float(e)
+    
     def evaluate_symbolic(self, substitutions: Dict[Any, Any]) -> 'Expression':
         return Expression.make(substitute_with_eval(sympify(self.underlying_expression), substitutions))
 

--- a/qctoolkit/expressions.py
+++ b/qctoolkit/expressions.py
@@ -75,8 +75,11 @@ class Expression(AnonymousSerializable, metaclass=_ExpressionMeta):
         return self._parse_evaluate_numeric_result(result, kwargs)
 
     def __float__(self):
-        e = self.evaluate_numeric()
-        return float(e)
+        if self.variables:
+            return NotImplemented
+        else:
+            e = self.evaluate_numeric()
+            return float(e)
     
     def evaluate_symbolic(self, substitutions: Dict[Any, Any]) -> 'Expression':
         return Expression.make(substitute_with_eval(sympify(self.underlying_expression), substitutions))

--- a/tests/annotation_tests.py
+++ b/tests/annotation_tests.py
@@ -7,7 +7,8 @@ import unittest
 
 src_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'qctoolkit')
 
-ignored_functions = ["__init__", "__new__", "__str__", "__repr__", "__hash__", "__len__", "__eq__", "__iter__"]
+ignored_functions = ["__init__", "__new__", "__str__", "__repr__", "__hash__", "__len__", "__eq__", "__iter__",
+                     "__float__", "__int__", "__bool__"]
 
 
 def assert_function_annotations(test_case: unittest.TestCase, func: ast.FunctionDef, name: str):


### PR DESCRIPTION
This allows one to write `float(pulse.calculate_duration())`

@terrorfisch @lucblom 