### PR TITLE
Fix/render update

### DIFF
--- a/qctoolkit/pulses/plotting.py
+++ b/qctoolkit/pulses/plotting.py
@@ -10,6 +10,7 @@ Functions:
 from typing import Dict, Tuple, Any, Generator, Optional
 
 import numpy as np
+import warnings
 
 from qctoolkit.utils.types import ChannelID
 from qctoolkit.pulses.pulse_template import PulseTemplate
@@ -44,7 +45,7 @@ def iter_waveforms(instruction_block: AbstractInstructionBlock,
             raise NotImplementedError('Rendering cannot handle instructions of type {}.'.format(type(instruction)))
 
 
-def render(sequence: AbstractInstructionBlock, sample_rate: float=10) -> Tuple[np.ndarray, Dict[ChannelID, np.ndarray]]:
+def render(sequence: AbstractInstructionBlock, sample_rate: float=10.0) -> Tuple[np.ndarray, Dict[ChannelID, np.ndarray]]:
     """'Render' an instruction sequence (sample all contained waveforms into an array).
 
     Args:
@@ -66,6 +67,8 @@ def render(sequence: AbstractInstructionBlock, sample_rate: float=10) -> Tuple[n
 
     # add one sample to see the end of the waveform
     sample_count = total_time * sample_rate + 1
+    if not float(sample_count).is_integer():
+        warnings.warn('Sample count not whole number. Casted to integer.')
     times = np.linspace(0, total_time, num=sample_count, dtype=float)
     # move the last sample inside the waveform
     times[-1] = np.nextafter(times[-1], times[-2])

--- a/qctoolkit/pulses/plotting.py
+++ b/qctoolkit/pulses/plotting.py
@@ -44,8 +44,13 @@ def iter_waveforms(instruction_block: AbstractInstructionBlock,
             raise NotImplementedError('Rendering cannot handle instructions of type {}.'.format(type(instruction)))
 
 
-def render(sequence: AbstractInstructionBlock, sample_rate: int=10) -> Tuple[np.ndarray, Dict[ChannelID, np.ndarray]]:
+def render(sequence: AbstractInstructionBlock, sample_rate: float=10) -> Tuple[np.ndarray, Dict[ChannelID, np.ndarray]]:
     """'Render' an instruction sequence (sample all contained waveforms into an array).
+
+    Args:
+        sequence (AbstractInstructionBlock): block of instructions representing a (sub)sequence
+            in the control flow of a pulse template instantiation.
+        sample_rate (float): The sample rate in GHz.
 
     Returns:
         a tuple (times, values) of numpy.ndarrays of similar size. times contains the time value


### PR DESCRIPTION
The sample_rate is currently ducktyped as integer with GHz as unit. The total time could be non-integer. Hence, a non-integer value for number of samples in np.linspace could be given. I changed the sample_rate to float type and added a warning for a non-integer sample_count.
