### PR TITLE
Fix/unsafe sample

### DIFF
--- a/qctoolkit/pulses/repetition_pulse_template.py
+++ b/qctoolkit/pulses/repetition_pulse_template.py
@@ -41,13 +41,16 @@ class RepetitionWaveform(Waveform):
                       sample_times: np.ndarray,
                       output_array: Union[np.ndarray, None]=None) -> np.ndarray:
         if output_array is None:
-            output_array = np.empty(len(sample_times))
+            output_array = np.empty_like(sample_times)
         body_duration = self._body.duration
-        for i in range(self._repetition_count):
-            indices = slice(*np.searchsorted(sample_times, (i*body_duration, (i+1)*body_duration)))
+        time = 0
+        for _ in range(self._repetition_count):
+            end = time + body_duration
+            indices = slice(*np.searchsorted(sample_times, (float(time), float(end)), 'left'))
             self._body.unsafe_sample(channel=channel,
-                                     sample_times=sample_times[indices],
+                                     sample_times=sample_times[indices] - time,
                                      output_array=output_array[indices])
+            time = end
         return output_array
 
     @property

--- a/qctoolkit/pulses/sequence_pulse_template.py
+++ b/qctoolkit/pulses/sequence_pulse_template.py
@@ -57,16 +57,18 @@ class SequenceWaveform(Waveform):
                       sample_times: np.ndarray,
                       output_array: Union[np.ndarray, None]=None) -> np.ndarray:
         if output_array is None:
-            output_array = np.empty(len(sample_times))
+            output_array = np.empty_like(sample_times)
         time = 0
         for subwaveform in self._sequenced_waveforms:
             # before you change anything here, make sure to understand the difference between basic and advanced
             # indexing in numpy and their copy/reference behaviour
-            indices = slice(*np.searchsorted(sample_times, (time, time+subwaveform.duration), 'left'))
+            end = time + subwaveform.duration
+
+            indices = slice(*np.searchsorted(sample_times, (float(time), float(end)), 'left'))
             subwaveform.unsafe_sample(channel=channel,
-                                      sample_times=sample_times[indices],
+                                      sample_times=sample_times[indices]-time,
                                       output_array=output_array[indices])
-            time += subwaveform.duration
+            time = end
         return output_array
 
     @property

--- a/tests/pulses/repetition_pulse_template_tests.py
+++ b/tests/pulses/repetition_pulse_template_tests.py
@@ -61,12 +61,15 @@ class RepetitionWaveformTest(unittest.TestCase):
         rwf = RepetitionWaveform(body=body_wf, repetition_count=10)
 
         sample_times = np.arange(80) * 70./80.
-        np.testing.assert_equal(rwf.unsafe_sample(channel='A', sample_times=sample_times), sample_times)
+        inner_sample_times = (sample_times.reshape((10, -1)) - (7 * np.arange(10))[:, np.newaxis]).ravel()
+
+        result = rwf.unsafe_sample(channel='A', sample_times=sample_times)
+        np.testing.assert_equal(result, inner_sample_times)
 
         output_expected = np.empty_like(sample_times)
         output_received = rwf.unsafe_sample(channel='A', sample_times=sample_times, output_array=output_expected)
         self.assertIs(output_expected, output_received)
-        np.testing.assert_equal(output_received, sample_times)
+        np.testing.assert_equal(output_received, inner_sample_times)
 
 
 class RepetitionPulseTemplateTest(unittest.TestCase):

--- a/tests/pulses/sequence_pulse_template_tests.py
+++ b/tests/pulses/sequence_pulse_template_tests.py
@@ -41,14 +41,14 @@ class SequenceWaveformTest(unittest.TestCase):
         self.assertEqual(len(swf2.compare_key), 3)
 
     def test_unsafe_sample(self):
-        dwfs = (DummyWaveform(duration=1., sample_output=np.linspace(5, 6, num=10)),
-                DummyWaveform(duration=3., sample_output=np.linspace(1, 2, num=30)),
-                DummyWaveform(duration=2., sample_output=np.linspace(8, 9, num=20)))
+        dwfs = (DummyWaveform(duration=1.),
+                DummyWaveform(duration=3.),
+                DummyWaveform(duration=2.))
 
         swf = SequenceWaveform(dwfs)
 
         sample_times = np.arange(0, 60)*0.1
-        expected_output = np.concatenate(tuple(dwf.sample_output for dwf in dwfs))
+        expected_output = np.concatenate((sample_times[:10], sample_times[10:40]-1, sample_times[40:]-4))
 
         output = swf.unsafe_sample('A', sample_times=sample_times)
         np.testing.assert_equal(expected_output, output)


### PR DESCRIPTION
The sampling of the compound waveforms `RepetitionWaveform` and `SequenceWaveform` was broken. Currently these waveforms are used to concatenate waveforms if they do not fullfill the requirements of the AWG (minimal length, etc)