### PR TITLE
Fix failing tests for deprecation warnings on Windows(?)

### DIFF
--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -178,12 +178,9 @@ class AtomicMultiChannelPulseTemplateTest(unittest.TestCase):
             AtomicMultiChannelPulseTemplate((non_atomic_pt, {'A': 'C'}), atomic_pt)
 
     def test_external_parameters_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            dummy = DummyPulseTemplate()
-            AtomicMultiChannelPulseTemplate(dummy, external_parameters={'a'})
-            self.assertEqual(1, len(w), msg="AtomicMultiChannelPulseTemplate did not issue a warning for argument external_parameters")
-            self.assertTrue("external_parameters" in str(w[-1].message),
-                            msg="AtomicMultiChannelPulseTemplate did not issue a warning for argument external_parameters")
+        with self.assertWarnsRegex(DeprecationWarning, "external_parameters",
+                                   msg="AtomicMultiChannelPulseTemplate did not issue a warning for argument external_parameters"):
+            AtomicMultiChannelPulseTemplate(DummyPulseTemplate(), external_parameters={'a'})
 
     def test_duration(self):
         sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}),

--- a/tests/pulses/sequence_pulse_template_tests.py
+++ b/tests/pulses/sequence_pulse_template_tests.py
@@ -106,12 +106,10 @@ class SequencePulseTemplateTest(unittest.TestCase):
                                                                    measurement_mapping=self.window_name_mapping))
 
     def test_external_parameters_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            dummy = DummyPulseTemplate()
+        dummy = DummyPulseTemplate()
+        with self.assertWarnsRegex(DeprecationWarning, "external_parameters",
+                                   msg="SequencePT did not issue a warning for argument external_parameters"):
             SequencePulseTemplate(dummy, external_parameters={'a'})
-            self.assertEqual(1, len(w), msg="SequencePT did not issue a warning for argument external_parameters")
-            self.assertTrue("external_parameters" in str(w[-1].message),
-                            msg="SequencePT did not issue a warning for argument external_parameters")
 
     def test_duration(self):
         pt = SequencePulseTemplate(DummyPulseTemplate(duration='a'),


### PR DESCRIPTION
Although the tests pass on Travis they fail on my machine. This PR simply replaces catching the warnings by hand with the unittest context manager for that.