### PR TITLE
Fix plot() to not crash on empty pulse

### DIFF
--- a/qctoolkit/pulses/plotting.py
+++ b/qctoolkit/pulses/plotting.py
@@ -111,7 +111,7 @@ def render(sequence: AbstractInstructionBlock,
     sample_count = total_time * sample_rate + 1
     if not float(sample_count).is_integer():
         warnings.warn('Sample count not whole number. Casted to integer.')
-    times = np.linspace(0, total_time, num=sample_count, dtype=float)
+    times = np.linspace(0, total_time, num=int(sample_count), dtype=float)
     # move the last sample inside the waveform
     times[-1] = np.nextafter(times[-1], times[-2])
 

--- a/qctoolkit/pulses/plotting.py
+++ b/qctoolkit/pulses/plotting.py
@@ -41,7 +41,7 @@ def iter_waveforms(instruction_block: AbstractInstructionBlock,
                 raise NotImplementedError("Instruction block contains an unexpected GOTO instruction.")
             return
         elif isinstance(instruction, STOPInstruction):
-            raise StopIteration()
+            return
         else:
             raise NotImplementedError('Rendering cannot handle instructions of type {}.'.format(type(instruction)))
 

--- a/tests/pulses/plotting_tests.py
+++ b/tests/pulses/plotting_tests.py
@@ -228,6 +228,9 @@ class PlotterTests(unittest.TestCase):
         self.assertEqual(expected_voltages, voltages)
 
     def test_plot_empty_pulse(self) -> None:
+        import matplotlib
+        matplotlib.use('svg') # use non-interactive backend so that test does not fail on travis
+
         pt = DummyPulseTemplate()
         with warnings.catch_warnings(record=True) as w:
             plot(pt, dict(), show=False)

--- a/tests/pulses/plotting_tests.py
+++ b/tests/pulses/plotting_tests.py
@@ -227,7 +227,7 @@ class PlotterTests(unittest.TestCase):
         self.assertEqual(expected_times, times)
         self.assertEqual(expected_voltages, voltages)
 
-    def test_empty_pulse(self) -> None:
+    def test_plot_empty_pulse(self) -> None:
         pt = DummyPulseTemplate()
         with warnings.catch_warnings(record=True) as w:
             plot(pt, dict(), show=False)

--- a/tests/pulses/plotting_tests.py
+++ b/tests/pulses/plotting_tests.py
@@ -1,7 +1,8 @@
 import unittest
 import numpy
+import warnings
 
-from qctoolkit.pulses.plotting import PlottingNotPossibleException, render, iter_waveforms, iter_instruction_block
+from qctoolkit.pulses.plotting import PlottingNotPossibleException, render, iter_waveforms, iter_instruction_block, plot
 from qctoolkit.pulses.instructions import InstructionBlock
 from qctoolkit.pulses.table_pulse_template import TablePulseTemplate
 from qctoolkit.pulses.sequence_pulse_template import SequencePulseTemplate
@@ -225,6 +226,13 @@ class PlotterTests(unittest.TestCase):
         # compare
         self.assertEqual(expected_times, times)
         self.assertEqual(expected_voltages, voltages)
+
+    def test_empty_pulse(self) -> None:
+        pt = DummyPulseTemplate()
+        with warnings.catch_warnings(record=True) as w:
+            plot(pt, dict(), show=False)
+            self.assertEqual(1, len(w), msg="plot() did not issue a warning for an empty pulse.")
+            self.assertTrue("empty" in str(w[-1].message), msg="plot() did not issue a warning for an empty pulse.")
 
 
 class PlottingNotPossibleExceptionTests(unittest.TestCase):


### PR DESCRIPTION
It will now issue a warning and return/show an empty plot.