### PR TITLE
backward-compatible implementations of get_serialization_data and deserialize

### DIFF
--- a/qctoolkit/pulses/function_pulse_template.py
+++ b/qctoolkit/pulses/function_pulse_template.py
@@ -120,6 +120,8 @@ class FunctionPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
         )
 
     def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
+        data = super().get_serialization_data(serializer)
+
         if serializer: # compatibility to old serialization routines, deprecated
             return dict(
                 duration_expression=self.__duration_expression,
@@ -128,13 +130,17 @@ class FunctionPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
                 measurement_declarations=self.measurement_declarations,
                 parameter_constraints=[str(c) for c in self.parameter_constraints]
             )
-        return dict(
+
+        local_data = dict(
             duration_expression=self.__duration_expression,
             expression=self.__expression,
             channel=self.__channel,
             measurements=self.measurement_declarations,
             parameter_constraints=[str(c) for c in self.parameter_constraints]
         )
+
+        data.update(**local_data)
+        return data
 
     @classmethod
     def deserialize(cls,

--- a/qctoolkit/pulses/function_pulse_template.py
+++ b/qctoolkit/pulses/function_pulse_template.py
@@ -119,31 +119,31 @@ class FunctionPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
             for name in parameters.keys() if (name in self.parameter_names)
         )
 
-    def get_serialization_data(self, serializer: Serializer) -> Dict[str, Any]:
+    def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
+        if serializer: # compatibility to old serialization routines, deprecated
+            return dict(
+                duration_expression=self.__duration_expression,
+                expression=self.__expression,
+                channel=self.__channel,
+                measurement_declarations=self.measurement_declarations,
+                parameter_constraints=[str(c) for c in self.parameter_constraints]
+            )
         return dict(
             duration_expression=self.__duration_expression,
             expression=self.__expression,
             channel=self.__channel,
-            measurement_declarations=self.measurement_declarations,
+            measurements=self.measurement_declarations,
             parameter_constraints=[str(c) for c in self.parameter_constraints]
         )
 
-    @staticmethod
-    def deserialize(serializer: Serializer,
-                    expression: Any,
-                    duration_expression: Any,
-                    channel: 'ChannelID',
-                    measurement_declarations: List[MeasurementDeclaration],
-                    parameter_constraints: List,
-                    identifier: Optional[bool]=None) -> 'FunctionPulseTemplate':
-        return FunctionPulseTemplate(
-            expression,
-            duration_expression,
-            channel=channel,
-            identifier=identifier,
-            measurements=measurement_declarations,
-            parameter_constraints=parameter_constraints
-        )
+    @classmethod
+    def deserialize(cls,
+                    serializer: Optional[Serializer]=None,
+                    **kwargs) -> 'FunctionPulseTemplate':
+        if serializer:
+            kwargs['measurements'] = kwargs['measurement_declarations'] # compatibility to old serialization routines, deprecated
+            del kwargs['measurement_declarations']
+        return super().deserialize(None, **kwargs)
 
     @property
     def integral(self) -> Dict[ChannelID, ExpressionScalar]:

--- a/qctoolkit/pulses/loop_pulse_template.py
+++ b/qctoolkit/pulses/loop_pulse_template.py
@@ -232,9 +232,9 @@ class ForLoopPulseTemplate(LoopPulseTemplate, MeasurementDefiner, ParameterConst
                       conditions: Dict[str, 'Condition']) -> bool:
         return any(parameters[parameter_name].requires_stop for parameter_name in self._loop_range.parameter_names)
 
-    def get_serialization_data(self, serializer: Serializer) -> Dict[str, Any]:
+    def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
         data = dict(
-            body=serializer.dictify(self.body),
+            body=self.body,
             loop_range=self._loop_range.to_tuple(),
             loop_index=self._loop_index,
         )
@@ -242,24 +242,23 @@ class ForLoopPulseTemplate(LoopPulseTemplate, MeasurementDefiner, ParameterConst
             data['parameter_constraints'] = [str(c) for c in self.parameter_constraints]
         if self.measurement_declarations:
             data['measurements'] = self.measurement_declarations
+
+        if serializer: # compatibility to old serialization routines, deprecated
+            data['body'] = serializer.dictify(data['body'])
+
         return data
 
-    @staticmethod
-    def deserialize(serializer: Serializer,
-                    body: Dict[str, Any],
-                    loop_range: Tuple,
-                    loop_index: str,
-                    identifier: Optional[str]=None,
-                    measurements: Optional[Sequence[str]]=None,
-                    parameter_constraints: Optional[Sequence[str]]=None) -> 'ForLoopPulseTemplate':
-        body = cast(PulseTemplate, serializer.deserialize(body))
-        return ForLoopPulseTemplate(body=body,
-                                    identifier=identifier,
-                                    loop_range=loop_range,
-                                    loop_index=loop_index,
-                                    measurements=measurements,
-                                    parameter_constraints=parameter_constraints
-                                    )
+    @classmethod
+    def deserialize(cls, serializer: Optional[Serializer]=None, **kwargs) -> 'ForLoopTemplate':
+                    # body: Dict[str, Any],
+                    # loop_range: Tuple,
+                    # loop_index: str,
+                    # identifier: Optional[str]=None,
+                    # measurements: Optional[Sequence[str]]=None,
+                    # parameter_constraints: Optional[Sequence[str]]=None) -> 'ForLoopPulseTemplate':
+        if serializer: # compatibility to old serialization routines, deprecated
+            kwargs['body'] = cast(PulseTemplate, serializer.deserialize(kwargs['body']))
+        return super().deserialize(None, **kwargs)
 
     @property
     def integral(self) -> Dict[ChannelID, ExpressionScalar]:
@@ -352,24 +351,23 @@ class WhileLoopPulseTemplate(LoopPulseTemplate):
                       conditions: Dict[str, Condition]) -> bool:
         return self.__obtain_condition_object(conditions).requires_stop()
 
-    def get_serialization_data(self, serializer: Serializer) -> Dict[str, Any]:
+    def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
         data = dict(
-            type=serializer.get_type_identifier(self),
             condition=self._condition,
-            body=serializer.dictify(self.body)
+            body=self.body
         )
+
+        if serializer: # compatibility to old serialization routines, deprecated
+            data['body'] = serializer.dictify(data['body'])
+
         return data
 
-    @staticmethod
-    def deserialize(serializer: Serializer,
-                    condition: str,
-                    body: Dict[str, Any],
-                    identifier: Optional[str]=None) -> 'WhileLoopPulseTemplate':
-        body = serializer.deserialize(body)
-        result = WhileLoopPulseTemplate(condition=condition,
-                                        body=body,
-                                        identifier=identifier)
-        return result
+    @classmethod
+    def deserialize(cls, serializer: Optional[Serializer]=None, **kwargs) -> 'WhileLoopPulseTemplate':
+        if serializer: # compatibility to old serialization routines, deprecated
+            kwargs['body'] = serializer.deserialize(kwargs['body'])
+
+        return super().deserialize(**kwargs)
 
     @property
     def integral(self) -> Dict[ChannelID, ExpressionScalar]:

--- a/qctoolkit/pulses/multi_channel_pulse_template.py
+++ b/qctoolkit/pulses/multi_channel_pulse_template.py
@@ -226,16 +226,18 @@ class AtomicMultiChannelPulseTemplate(AtomicPulseTemplate, ParameterConstrainer)
         return any(st.requires_stop(parameters, conditions) for st in self._subtemplates)
 
     def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
-        data = dict(subtemplates=self.subtemplates)
+        data = super().get_serialization_data(serializer)
+        data['subtemplates'] = self.subtemplates
 
         if serializer: # compatibility to old serialization routines, deprecated
+            data = dict()
             data['subtemplates'] = [serializer.dictify(subtemplate) for subtemplate in self.subtemplates]
 
         if self.parameter_constraints:
             data['parameter_constraints'] = [str(constraint) for constraint in self.parameter_constraints]
-
         if self.measurement_declarations:
             data['measurements'] = self.measurement_declarations
+
         return data
 
     @classmethod

--- a/qctoolkit/pulses/multi_channel_pulse_template.py
+++ b/qctoolkit/pulses/multi_channel_pulse_template.py
@@ -225,8 +225,11 @@ class AtomicMultiChannelPulseTemplate(AtomicPulseTemplate, ParameterConstrainer)
                       conditions: Dict[str, 'Condition']) -> bool:
         return any(st.requires_stop(parameters, conditions) for st in self._subtemplates)
 
-    def get_serialization_data(self, serializer: Serializer) -> Dict[str, Any]:
-        data = dict(subtemplates=[serializer.dictify(subtemplate) for subtemplate in self.subtemplates])
+    def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
+        data = dict(subtemplates=self.subtemplates)
+
+        if serializer: # compatibility to old serialization routines, deprecated
+            data['subtemplates'] = [serializer.dictify(subtemplate) for subtemplate in self.subtemplates]
 
         if self.parameter_constraints:
             data['parameter_constraints'] = [str(constraint) for constraint in self.parameter_constraints]
@@ -235,16 +238,15 @@ class AtomicMultiChannelPulseTemplate(AtomicPulseTemplate, ParameterConstrainer)
             data['measurements'] = self.measurement_declarations
         return data
 
-    @staticmethod
-    def deserialize(serializer: Serializer,
-                    subtemplates: Iterable[Dict[str, Any]],
-                    parameter_constraints: Optional[Any]=None,
-                    identifier: Optional[str]=None,
-                    measurements: Optional[List[MeasurementDeclaration]]=None) -> 'AtomicMultiChannelPulseTemplate':
-        subtemplates = [serializer.deserialize(st) for st in subtemplates]
-        return AtomicMultiChannelPulseTemplate(*subtemplates,
-                                               parameter_constraints=parameter_constraints,
-                                               identifier=identifier, measurements=measurements)
+    @classmethod
+    def deserialize(cls, serializer: Optional[Serializer]=None, **kwargs) -> 'AtomicMultiChannelPulseTemplate':
+        subtemplates = kwargs['subtemplates']
+        del kwargs['subtemplates']
+
+        if serializer: # compatibility to old serialization routines, deprecated
+            subtemplates = [serializer.deserialize(st) for st in subtemplates]
+
+        return cls(*subtemplates, **kwargs)
 
     @property
     def integral(self) -> Dict[ChannelID, ExpressionScalar]:

--- a/qctoolkit/pulses/point_pulse_template.py
+++ b/qctoolkit/pulses/point_pulse_template.py
@@ -101,9 +101,13 @@ class PointPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
         return self._entries
 
     def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
-        data = {'time_point_tuple_list': [entry.get_serialization_data()
-                                          for entry in self._entries],
-                'channel_names':       self._channels}
+        data = super().get_serialization_data(serializer)
+
+        if serializer: # compatibility to old serialization routines, deprecated
+            data = dict()
+
+        data['time_point_tuple_list'] = [entry.get_serialization_data() for entry in self._entries]
+        data['channel_names'] = self._channels
         if self.parameter_constraints:
             data['parameter_constraints'] = [str(c) for c in self.parameter_constraints]
         if self.measurement_declarations:

--- a/qctoolkit/pulses/point_pulse_template.py
+++ b/qctoolkit/pulses/point_pulse_template.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Union, Set, Dict, Sequence
+from typing import Optional, List, Union, Set, Dict, Sequence, Any
 from numbers import Real
 import itertools
 import numbers
@@ -14,6 +14,7 @@ from qctoolkit.pulses.parameters import Parameter, ParameterNotProvidedException
 from qctoolkit.pulses.pulse_template import AtomicPulseTemplate, MeasurementDeclaration
 from qctoolkit.pulses.table_pulse_template import TableEntry, EntryInInit, TableWaveform, TableWaveformEntry
 from qctoolkit.pulses.multi_channel_pulse_template import MultiChannelWaveform
+from qctoolkit.serialization import Serializer
 
 
 __all__ = ["PointWaveform", "PointPulseTemplate", "PointPulseEntry", "PointWaveformEntry", "InvalidPointDimension"]
@@ -99,7 +100,7 @@ class PointPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
     def point_pulse_entries(self) -> Sequence[PointPulseEntry]:
         return self._entries
 
-    def get_serialization_data(self, serializer) -> Dict:
+    def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
         data = {'time_point_tuple_list': [entry.get_serialization_data()
                                           for entry in self._entries],
                 'channel_names':       self._channels}
@@ -108,10 +109,6 @@ class PointPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
         if self.measurement_declarations:
             data['measurements'] = self.measurement_declarations
         return data
-
-    @staticmethod
-    def deserialize(serializer, **kwargs) -> 'PointPulseTemplate':
-        return PointPulseTemplate(**kwargs)
 
     @property
     def duration(self) -> Expression:

--- a/qctoolkit/pulses/repetition_pulse_template.py
+++ b/qctoolkit/pulses/repetition_pulse_template.py
@@ -164,17 +164,19 @@ class RepetitionPulseTemplate(LoopPulseTemplate, ParameterConstrainer, Measureme
         return any(parameters[v].requires_stop for v in self.repetition_count.variables)
 
     def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
-        data = dict(
-            body=self.body,
-            repetition_count=self.repetition_count.original_expression
-        )
+        data = super().get_serialization_data(serializer)
+        data['body'] = self.body
+
+        if serializer: # compatibility to old serialization routines, deprecated
+            data = dict()
+            data['body'] = serializer.dictify(self.body)
+
+        data['repetition_count'] = self.repetition_count.original_expression
+
         if self.parameter_constraints:
             data['parameter_constraints'] = [str(c) for c in self.parameter_constraints]
         if self.measurement_declarations:
             data['measurements'] = self.measurement_declarations
-
-        if serializer: # compatibility to old serialization routines, deprecated
-            data['body'] = serializer.dictify(self.body)
 
         return data
 

--- a/qctoolkit/pulses/sequence_pulse_template.py
+++ b/qctoolkit/pulses/sequence_pulse_template.py
@@ -212,14 +212,18 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
                            target_block=instruction_block)
 
     def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
-        data = dict(subtemplates=self.subtemplates)
+        data = super().get_serialization_data(serializer)
+        data['subtemplates'] = self.subtemplates
+
+        if serializer: # compatibility to old serialization routines, deprecated
+            data = dict()
+            data['subtemplates'] = [serializer.dictify(subtemplate) for subtemplate in self.subtemplates]
+
         if self.parameter_constraints:
             data['parameter_constraints'] = [str(c) for c in self.parameter_constraints]
         if self.measurement_declarations:
             data['measurements'] = self.measurement_declarations
 
-        if serializer: # compatibility to old serialization routines, deprecated
-            data['subtemplates'] = [serializer.dictify(subtemplate) for subtemplate in self.subtemplates]
         return data
 
     @classmethod

--- a/qctoolkit/pulses/sequence_pulse_template.py
+++ b/qctoolkit/pulses/sequence_pulse_template.py
@@ -211,7 +211,7 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
                            channel_mapping=channel_mapping,
                            target_block=instruction_block)
 
-    def get_serialization_data(self, serializer: Serializer=None) -> Dict[str, Any]:
+    def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
         data = dict(subtemplates=self.subtemplates)
         if self.parameter_constraints:
             data['parameter_constraints'] = [str(c) for c in self.parameter_constraints]

--- a/qctoolkit/pulses/table_pulse_template.py
+++ b/qctoolkit/pulses/table_pulse_template.py
@@ -321,7 +321,7 @@ class TablePulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
         except KeyError as key_error:
             raise ParameterNotProvidedException(str(key_error)) from key_error
 
-    def get_serialization_data(self, serializer: Serializer) -> Dict[str, Any]:
+    def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
         return dict(
             entries=dict(
                 (channel, [entry.get_serialization_data()
@@ -331,18 +331,18 @@ class TablePulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
             parameter_constraints=[str(c) for c in self.parameter_constraints],
             measurements=self.measurement_declarations
         )
-
-    @staticmethod
-    def deserialize(serializer: Serializer,
-                    entries: Dict[ChannelID, List[EntryInInit]],
-                    parameter_constraints: List[str],
-                    measurements: List[MeasurementDeclaration],
-                    identifier: Optional[str]=None) -> 'TablePulseTemplate':
-        return TablePulseTemplate(entries=entries,
-                                  identifier=identifier,
-                                  parameter_constraints=parameter_constraints,
-                                  measurements=measurements,
-                                  consistency_check=False)
+    #
+    # @classmethod
+    # def deserialize(serializer: Serializer,
+    #                 entries: Dict[ChannelID, List[EntryInInit]],
+    #                 parameter_constraints: List[str],
+    #                 measurements: List[MeasurementDeclaration],
+    #                 identifier: Optional[str]=None) -> 'TablePulseTemplate':
+    #     return TablePulseTemplate(entries=entries,
+    #                               identifier=identifier,
+    #                               parameter_constraints=parameter_constraints,
+    #                               measurements=measurements,
+    #                               consistency_check=False)
 
     def build_waveform(self,
                        parameters: Dict[str, numbers.Real],

--- a/qctoolkit/pulses/table_pulse_template.py
+++ b/qctoolkit/pulses/table_pulse_template.py
@@ -322,7 +322,12 @@ class TablePulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
             raise ParameterNotProvidedException(str(key_error)) from key_error
 
     def get_serialization_data(self, serializer: Optional[Serializer]=None) -> Dict[str, Any]:
-        return dict(
+        data = super().get_serialization_data(serializer)
+
+        if serializer: # compatibility to old serialization routines, deprecated
+            data = dict()
+
+        local_data = dict(
             entries=dict(
                 (channel, [entry.get_serialization_data()
                            for entry in channel_entries])
@@ -331,18 +336,8 @@ class TablePulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
             parameter_constraints=[str(c) for c in self.parameter_constraints],
             measurements=self.measurement_declarations
         )
-    #
-    # @classmethod
-    # def deserialize(serializer: Serializer,
-    #                 entries: Dict[ChannelID, List[EntryInInit]],
-    #                 parameter_constraints: List[str],
-    #                 measurements: List[MeasurementDeclaration],
-    #                 identifier: Optional[str]=None) -> 'TablePulseTemplate':
-    #     return TablePulseTemplate(entries=entries,
-    #                               identifier=identifier,
-    #                               parameter_constraints=parameter_constraints,
-    #                               measurements=measurements,
-    #                               consistency_check=False)
+        data.update(**local_data)
+        return data
 
     def build_waveform(self,
                        parameters: Dict[str, numbers.Real],

--- a/qctoolkit/serialization.py
+++ b/qctoolkit/serialization.py
@@ -669,6 +669,9 @@ class PulseStorage:
     def clear(self) -> None:
         self._temporary_storage.clear()
 
+    def __del__(self) -> None:
+        self.flush()
+
 
 class JSONSerializableDecoder(json.JSONDecoder):
 

--- a/tests/pulses/function_pulse_tests.py
+++ b/tests/pulses/function_pulse_tests.py
@@ -7,11 +7,12 @@ from qctoolkit.pulses.function_pulse_template import FunctionPulseTemplate,\
     FunctionWaveform
 from qctoolkit.serialization import Serializer, Serializable, PulseStorage
 from qctoolkit.expressions import Expression
-from qctoolkit.pulses.parameters import ParameterConstraintViolation
+from qctoolkit.pulses.parameters import ParameterConstraintViolation, ParameterConstraint
 
 from tests.serialization_dummies import DummySerializer, DummyStorageBackend
 from tests.pulses.sequencing_dummies import DummyParameter
 from tests.pulses.measurement_tests import MeasurementDefinerTest, ParameterConstrainerTest
+from tests.serialization_tests import SerializableTests
 
 
 class FunctionPulseTest(unittest.TestCase):
@@ -82,76 +83,30 @@ class FunctionPulsePropertyTest(FunctionPulseTest):
         self.assertEqual(expected_parameter_names, template.parameter_names)
 
 
-class FunctionPulseSerializationTest(FunctionPulseTest):
+class FunctionPulseSerializationTest(SerializableTests, unittest.TestCase):
 
-    def test_get_serialization_data_with_identifier(self) -> None:
-        template = FunctionPulseTemplate(self.s, self.s2, channel='A',
-                                         measurements=self.meas_list,
-                                         parameter_constraints=self.constraints,
-                                         identifier='hugo')
+    @property
+    def class_to_test(self):
+        return FunctionPulseTemplate
 
-        expected_data = {
-             'duration_expression': str(self.s2),
-             'expression': str(self.s),
-             'channel': 'A',
-             'measurements': self.meas_list,
-             'parameter_constraints': self.constraints,
-            Serializable.type_identifier_name: FunctionPulseTemplate.get_type_identifier(),
-            Serializable.identifier_name: 'hugo'
+    def make_kwargs(self):
+        return {
+            'expression': Expression('a + b * t'),
+            'duration_expression': Expression('c'),
+            'channel': 'A',
+            'measurements': [('mw', 1, 1), ('mw', 'x', 'z'), ('drup', 'j', 'u')],
+            'parameter_constraints': [str(ParameterConstraint('a < b')), str(ParameterConstraint('c > 1')),
+                                      str(ParameterConstraint('d > c'))]
         }
-        self.assertEqual(expected_data, template.get_serialization_data())
 
-    def test_get_serialization_data_without_identifier(self) -> None:
-        template = FunctionPulseTemplate(self.s, self.s2, channel='A',
-                                         measurements=self.meas_list,
-                                         parameter_constraints=self.constraints)
-
-        expected_data = {
-             'duration_expression': str(self.s2),
-             'expression': str(self.s),
-             'channel': 'A',
-             'measurements': self.meas_list,
-             'parameter_constraints': self.constraints,
-            Serializable.type_identifier_name: FunctionPulseTemplate.get_type_identifier()
-        }
-        self.assertEqual(expected_data, template.get_serialization_data())
-
-    def test_deserialize(self) -> None:
-        basic_data = dict(duration_expression=Expression(self.s2),
-                          expression=Expression(self.s),
-                          channel='A',
-                          identifier='hugo',
-                          measurements=self.meas_list,
-                          parameter_constraints=self.constraints)
-        template = FunctionPulseTemplate.deserialize(**basic_data)
-        self.assertEqual('hugo', template.identifier)
-        self.assertEqual({'a', 'b', 'c', 'x', 'z', 'j', 'u', 'd'}, template.parameter_names)
-        self.assertEqual(template.measurement_declarations,
-                         self.meas_list)
-        self.assertEqual(basic_data['duration_expression'], template.duration)
-        self.assertEqual(basic_data['expression'], template.expression)
-
-    def test_serializer_integration(self):
-        ref_template = FunctionPulseTemplate(self.s, self.s2, channel='A',
-                                             measurements=self.meas_list,
-                                             parameter_constraints=self.constraints,
-                                             identifier='foo')
-
-        storage_backend = DummyStorageBackend()
-        pulse_storage = PulseStorage(storage_backend)
-        pulse_storage[ref_template.identifier] = ref_template
-        pulse_storage.flush()
-
-        pulse_storage = PulseStorage(storage_backend) #recreate object to clear temporary storage
-        template = pulse_storage[ref_template.identifier]
-
-        self.assertIsInstance(template, FunctionPulseTemplate)
-        self.assertEqual('foo', template.identifier)
-        self.assertEqual(ref_template.parameter_names, template.parameter_names)
-        self.assertEqual(ref_template.measurement_declarations, template.measurement_declarations)
-        self.assertEqual(ref_template.parameter_constraints, template.parameter_constraints)
-        self.assertEqual(ref_template.duration, template.duration)
-        self.assertEqual(ref_template.expression, template.expression)
+    def assert_equal_instance(self, lhs: FunctionPulseTemplate, rhs: FunctionPulseTemplate):
+        self.assertIsInstance(lhs, FunctionPulseTemplate)
+        self.assertIsInstance(rhs, FunctionPulseTemplate)
+        self.assertEqual(lhs.parameter_names, rhs.parameter_names)
+        self.assertEqual(lhs.measurement_declarations, rhs.measurement_declarations)
+        self.assertEqual(lhs.parameter_constraints, rhs.parameter_constraints)
+        self.assertEqual(lhs.duration, rhs.duration)
+        self.assertEqual(lhs.expression, rhs.expression)
 
 
 class FunctionPulseOldSerializationTests(FunctionPulseTest):

--- a/tests/pulses/loop_pulse_template_tests.py
+++ b/tests/pulses/loop_pulse_template_tests.py
@@ -7,13 +7,13 @@ from qctoolkit.expressions import Expression, ExpressionScalar
 from qctoolkit.pulses.loop_pulse_template import ForLoopPulseTemplate, WhileLoopPulseTemplate,\
     ConditionMissingException, ParametrizedRange, LoopIndexNotUsedException, LoopPulseTemplate
 from qctoolkit.pulses.parameters import ConstantParameter, InvalidParameterNameException, ParameterConstraintViolation,\
-    ParameterNotProvidedException
+    ParameterNotProvidedException, ParameterConstraint
 from qctoolkit.pulses.instructions import MEASInstruction
-from qctoolkit.serialization import Serializable
 
 from tests.pulses.sequencing_dummies import DummyCondition, DummyPulseTemplate, DummySequencer, DummyInstructionBlock,\
     DummyParameter
 from tests.serialization_dummies import DummySerializer
+from tests.serialization_tests import SerializableTests
 
 
 class DummyLoopPulseTemplate(LoopPulseTemplate):
@@ -33,7 +33,7 @@ class LoopPulseTemplateTests(unittest.TestCase):
     def test_defined_channels(self):
         body = DummyPulseTemplate(defined_channels={'A'})
         tpl = DummyLoopPulseTemplate(body)
-        self.assertIs(tpl.defined_channels, body.defined_channels)
+        self.assertEqual(tpl.defined_channels, body.defined_channels)
 
     def test_measurement_names(self):
         body = DummyPulseTemplate(measurement_names={'A'})
@@ -229,86 +229,29 @@ class ForLoopPulseTemplateTest(unittest.TestCase):
         self.assertEqual(expected, pulse.integral)
 
 
-class ForLoopPulseTemplateSerializationTests(unittest.TestCase):
+class ForLoopPulseTemplateSerializationTests(SerializableTests, unittest.TestCase):
 
-    def test_get_serialization_data_minimal_with_identifier(self) -> None:
-        dt = DummyPulseTemplate(parameter_names={'i'})
-        flt = ForLoopPulseTemplate(body=dt, loop_index='i', loop_range=('A', 'B'), identifier='hugo')
+    @property
+    def class_to_test(self):
+        return ForLoopPulseTemplate
 
-        data = flt.get_serialization_data()
-        expected_data = {
-            'body': dt,
-             'loop_range': ('A', 'B', 1),
-             'loop_index': 'i',
-            Serializable.type_identifier_name: ForLoopPulseTemplate.get_type_identifier(),
-            Serializable.identifier_name: 'hugo'
-        }
-        self.assertEqual(expected_data, data)
-
-    def test_get_serialization_data_minimal_without_identifier(self) -> None:
-        dt = DummyPulseTemplate(parameter_names={'i'})
-        flt = ForLoopPulseTemplate(body=dt, loop_index='i', loop_range=('A', 'B'))
-
-        data = flt.get_serialization_data()
-        expected_data = {
-            'body': dt,
-             'loop_range': ('A', 'B', 1),
-             'loop_index': 'i',
-            Serializable.type_identifier_name: ForLoopPulseTemplate.get_type_identifier()
-        }
-        self.assertEqual(expected_data, data)
-
-    def test_get_serialization_data_all_features(self) -> None:
-        measurements = [('a', 0, 1), ('b', 1, 1)]
-        parameter_constraints = ['foo < 3']
-
-        dt = DummyPulseTemplate(parameter_names={'i'})
-        flt = ForLoopPulseTemplate(body=dt, loop_index='i', loop_range=('A', 'B'),
-                                   measurements=measurements, parameter_constraints=parameter_constraints)
-
-        data = flt.get_serialization_data()
-        expected_data = {
-            'body': dt,
-            'loop_range': ('A', 'B', 1),
+    def make_kwargs(self):
+        return {
+            'body': DummyPulseTemplate(parameter_names={'i'}),
             'loop_index': 'i',
-            'measurements': measurements,
-            'parameter_constraints': parameter_constraints,
-            Serializable.type_identifier_name: ForLoopPulseTemplate.get_type_identifier()
+            'loop_range': ('A', 'B', 1),
+            'parameter_constraints': [str(ParameterConstraint('foo < 3'))],
+            'measurements': [('a', 0, 1), ('b', 1, 1)]
         }
-        self.assertEqual(data, expected_data)
 
-    def test_deserialize_minimal(self) -> None:
-        dt = DummyPulseTemplate(parameter_names={'i'})
-
-        data = dict(body=dt,
-                    loop_range=('A', 'B', 1),
-                    loop_index='i',
-                    identifier='meh')
-
-        flt = ForLoopPulseTemplate.deserialize(**data)
-        self.assertEqual(flt.identifier, 'meh')
-        self.assertEqual(flt.body, dt)
-        self.assertEqual(flt.loop_index, 'i')
-        self.assertEqual(flt.loop_range.to_tuple(), ('A', 'B', 1))
-
-    def test_deserialize_all_features(self) -> None:
-        dt = DummyPulseTemplate(parameter_names={'i'})
-
-        measurements = [('a', 0, 1), ('b', 1, 1)]
-        parameter_constraints = ['foo < 3']
-
-        data = dict(body=dt,
-                    loop_range=('A', 'B', 1),
-                    loop_index='i',
-                    measurements=measurements,
-                    parameter_constraints=parameter_constraints)
-
-        flt = ForLoopPulseTemplate.deserialize(**data)
-        self.assertIs(flt.body, dt)
-        self.assertEqual(flt.loop_index, 'i')
-        self.assertEqual(flt.loop_range.to_tuple(), ('A', 'B', 1))
-        self.assertEqual(flt.measurement_declarations, measurements)
-        self.assertEqual([str(c) for c in flt.parameter_constraints], parameter_constraints)
+    def assert_equal_instance(self, lhs: ForLoopPulseTemplate, rhs: ForLoopPulseTemplate):
+        self.assertIsInstance(lhs, ForLoopPulseTemplate)
+        self.assertIsInstance(rhs, ForLoopPulseTemplate)
+        self.assertEqual(lhs.body, rhs.body)
+        self.assertEqual(lhs.loop_index, rhs.loop_index)
+        self.assertEqual(lhs.loop_range.to_tuple(), rhs.loop_range.to_tuple())
+        self.assertEqual(lhs.parameter_constraints, rhs.parameter_constraints)
+        self.assertEqual(lhs.measurement_declarations, rhs.measurement_declarations)
 
 
 class ForLoopPulseTemplateOldSerializationTests(unittest.TestCase):
@@ -501,53 +444,23 @@ class WhileLoopPulseTemplateSequencingTests(unittest.TestCase):
             t.build_sequence(sequencer, {}, {}, {}, block)
 
 
-class WhileLoopPulseTemplateSerializationTests(unittest.TestCase):
+class WhileLoopPulseTemplateSerializationTests(SerializableTests, unittest.TestCase):
 
-    def test_get_serialization_data_with_identifier(self) -> None:
-        body = DummyPulseTemplate()
-        condition_name = 'foo_cond'
-        identifier = 'foo_loop'
-        t = WhileLoopPulseTemplate(condition_name, body, identifier=identifier)
+    @property
+    def class_to_test(self):
+        return WhileLoopPulseTemplate
 
-        expected_data = {
-            'body': body,
-            'condition': condition_name,
-            Serializable.type_identifier_name: WhileLoopPulseTemplate.get_type_identifier(),
-            Serializable.identifier_name: identifier
+    def make_kwargs(self):
+        return {
+            'body': DummyPulseTemplate(),
+            'condition': 'foo_cond'
         }
 
-        data = t.get_serialization_data()
-        self.assertEqual(expected_data, data)
-
-    def test_get_serialization_data_without_identifier(self) -> None:
-        body = DummyPulseTemplate()
-        condition_name = 'foo_cond'
-        t = WhileLoopPulseTemplate(condition_name, body)
-
-        expected_data = {
-            'body': body,
-            'condition': condition_name,
-            Serializable.type_identifier_name: WhileLoopPulseTemplate.get_type_identifier()
-        }
-
-        data = t.get_serialization_data()
-        self.assertEqual(expected_data, data)
-
-    def test_deserialize(self) -> None:
-        body = DummyPulseTemplate()
-        data = dict(
-            identifier='foo_loop',
-            condition='foo_cond',
-            body=body
-        )
-
-        # deserialize
-        result = WhileLoopPulseTemplate.deserialize(**data)
-
-        # compare
-        self.assertIs(body, result.body)
-        self.assertEqual(data['condition'], result.condition)
-        self.assertEqual(data['identifier'], result.identifier)
+    def assert_equal_instance(self, lhs: WhileLoopPulseTemplate, rhs: WhileLoopPulseTemplate):
+        self.assertIsInstance(lhs, WhileLoopPulseTemplate)
+        self.assertIsInstance(rhs, WhileLoopPulseTemplate)
+        self.assertEqual(lhs.body, rhs.body)
+        self.assertEqual(lhs.condition, rhs.condition)
 
 
 class WhileLoopPulseTemplateOldSerializationTests(unittest.TestCase):

--- a/tests/pulses/loop_pulse_template_tests.py
+++ b/tests/pulses/loop_pulse_template_tests.py
@@ -216,24 +216,17 @@ class ForLoopPulseTemplateTest(unittest.TestCase):
         parameters['A'] = DummyParameter(requires_stop=True)
         self.assertTrue(flt.requires_stop(parameters, dict()))
 
-    def test_get_serialization_data_minimal(self):
-
+    def test_get_serialization_data_minimal(self) -> None:
         dt = DummyPulseTemplate(parameter_names={'i'})
         flt = ForLoopPulseTemplate(body=dt, loop_index='i', loop_range=('A', 'B'))
 
-        def check_dt(to_dictify) -> str:
-            self.assertIs(to_dictify, dt)
-            return 'dt'
-
-        serializer = DummySerializer(serialize_callback=check_dt)
-
-        data = flt.get_serialization_data(serializer)
-        expected_data = dict(body='dt',
+        data = flt.get_serialization_data()
+        expected_data = dict(body=dt,
                              loop_range=('A', 'B', 1),
                              loop_index='i')
         self.assertEqual(data, expected_data)
 
-    def test_get_serialization_data_all_features(self):
+    def test_get_serialization_data_all_features(self) -> None:
         measurements = [('a', 0, 1), ('b', 1, 1)]
         parameter_constraints = ['foo < 3']
 
@@ -241,70 +234,149 @@ class ForLoopPulseTemplateTest(unittest.TestCase):
         flt = ForLoopPulseTemplate(body=dt, loop_index='i', loop_range=('A', 'B'),
                                    measurements=measurements, parameter_constraints=parameter_constraints)
 
-        def check_dt(to_dictify) -> str:
-            self.assertIs(to_dictify, dt)
-            return 'dt'
-
-        serializer = DummySerializer(serialize_callback=check_dt)
-
-        data = flt.get_serialization_data(serializer)
-        expected_data = dict(body='dt',
+        data = flt.get_serialization_data()
+        expected_data = dict(body=dt,
                              loop_range=('A', 'B', 1),
                              loop_index='i',
                              measurements=measurements,
                              parameter_constraints=parameter_constraints)
         self.assertEqual(data, expected_data)
 
-    def test_deserialize_minimal(self):
-        body_str = 'dt'
+    def test_deserialize_minimal(self) -> None:
         dt = DummyPulseTemplate(parameter_names={'i'})
 
-        def make_dt(ident: str):
-            self.assertEqual(body_str, ident)
-            return ident
-
-        data = dict(body=body_str,
+        data = dict(body=dt,
                     loop_range=('A', 'B', 1),
                     loop_index='i',
                     identifier='meh')
 
-        serializer = DummySerializer(deserialize_callback=make_dt)
-        serializer.subelements['dt'] = dt
-
-        flt = ForLoopPulseTemplate.deserialize(serializer, **data)
+        flt = ForLoopPulseTemplate.deserialize(**data)
         self.assertEqual(flt.identifier, 'meh')
         self.assertEqual(flt.body, dt)
         self.assertEqual(flt.loop_index, 'i')
         self.assertEqual(flt.loop_range.to_tuple(), ('A', 'B', 1))
 
-    def test_deserialize_all_features(self):
-        body_str = 'dt'
+    def test_deserialize_all_features(self) -> None:
         dt = DummyPulseTemplate(parameter_names={'i'})
 
         measurements = [('a', 0, 1), ('b', 1, 1)]
         parameter_constraints = ['foo < 3']
 
-        def make_dt(ident: str):
-            self.assertEqual(body_str, ident)
-            return ident
-
-        data = dict(body=body_str,
+        data = dict(body=dt,
                     loop_range=('A', 'B', 1),
                     loop_index='i',
                     identifier='meh',
                     measurements=measurements,
                     parameter_constraints=parameter_constraints)
 
-        serializer = DummySerializer(deserialize_callback=make_dt)
-        serializer.subelements['dt'] = dt
-
-        flt = ForLoopPulseTemplate.deserialize(serializer, **data)
+        flt = ForLoopPulseTemplate.deserialize(**data)
         self.assertEqual(flt.identifier, 'meh')
         self.assertIs(flt.body, dt)
         self.assertEqual(flt.loop_index, 'i')
         self.assertEqual(flt.loop_range.to_tuple(), ('A', 'B', 1))
         self.assertEqual(flt.measurement_declarations, measurements)
         self.assertEqual([str(c) for c in flt.parameter_constraints], parameter_constraints)
+
+    def test_get_serialization_data_minimal_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="ForLoopPT does not issue warning for old serialization routines."):
+            dt = DummyPulseTemplate(parameter_names={'i'})
+            flt = ForLoopPulseTemplate(body=dt, loop_index='i', loop_range=('A', 'B'))
+
+            def check_dt(to_dictify) -> str:
+                self.assertIs(to_dictify, dt)
+                return 'dt'
+
+            serializer = DummySerializer(serialize_callback=check_dt)
+
+            data = flt.get_serialization_data(serializer)
+            expected_data = dict(body='dt',
+                                 loop_range=('A', 'B', 1),
+                                 loop_index='i')
+            self.assertEqual(data, expected_data)
+
+    def test_get_serialization_data_all_features_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="ForLoopPT does not issue warning for old serialization routines."):
+            measurements = [('a', 0, 1), ('b', 1, 1)]
+            parameter_constraints = ['foo < 3']
+
+            dt = DummyPulseTemplate(parameter_names={'i'})
+            flt = ForLoopPulseTemplate(body=dt, loop_index='i', loop_range=('A', 'B'),
+                                       measurements=measurements, parameter_constraints=parameter_constraints)
+
+            def check_dt(to_dictify) -> str:
+                self.assertIs(to_dictify, dt)
+                return 'dt'
+
+            serializer = DummySerializer(serialize_callback=check_dt)
+
+            data = flt.get_serialization_data(serializer)
+            expected_data = dict(body='dt',
+                                 loop_range=('A', 'B', 1),
+                                 loop_index='i',
+                                 measurements=measurements,
+                                 parameter_constraints=parameter_constraints)
+            self.assertEqual(data, expected_data)
+
+    def test_deserialize_minimal_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="ForLoopPT does not issue warning for old serialization routines."):
+            body_str = 'dt'
+            dt = DummyPulseTemplate(parameter_names={'i'})
+
+            def make_dt(ident: str):
+                self.assertEqual(body_str, ident)
+                return ident
+
+            data = dict(body=body_str,
+                        loop_range=('A', 'B', 1),
+                        loop_index='i',
+                        identifier='meh')
+
+            serializer = DummySerializer(deserialize_callback=make_dt)
+            serializer.subelements['dt'] = dt
+
+            flt = ForLoopPulseTemplate.deserialize(serializer, **data)
+            self.assertEqual(flt.identifier, 'meh')
+            self.assertEqual(flt.body, dt)
+            self.assertEqual(flt.loop_index, 'i')
+            self.assertEqual(flt.loop_range.to_tuple(), ('A', 'B', 1))
+
+    def test_deserialize_all_features_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="ForLoopPT does not issue warning for old serialization routines."):
+            body_str = 'dt'
+            dt = DummyPulseTemplate(parameter_names={'i'})
+
+            measurements = [('a', 0, 1), ('b', 1, 1)]
+            parameter_constraints = ['foo < 3']
+
+            def make_dt(ident: str):
+                self.assertEqual(body_str, ident)
+                return ident
+
+            data = dict(body=body_str,
+                        loop_range=('A', 'B', 1),
+                        loop_index='i',
+                        identifier='meh',
+                        measurements=measurements,
+                        parameter_constraints=parameter_constraints)
+
+            serializer = DummySerializer(deserialize_callback=make_dt)
+            serializer.subelements['dt'] = dt
+
+            flt = ForLoopPulseTemplate.deserialize(serializer, **data)
+            self.assertEqual(flt.identifier, 'meh')
+            self.assertIs(flt.body, dt)
+            self.assertEqual(flt.loop_index, 'i')
+            self.assertEqual(flt.loop_range.to_tuple(), ('A', 'B', 1))
+            self.assertEqual(flt.measurement_declarations, measurements)
+            self.assertEqual([str(c) for c in flt.parameter_constraints], parameter_constraints)
 
     def test_integral(self) -> None:
         dummy = DummyPulseTemplate(defined_channels={'A', 'B'},
@@ -412,32 +484,65 @@ class LoopPulseTemplateSerializationTests(unittest.TestCase):
         identifier = 'foo_loop'
         t = WhileLoopPulseTemplate(condition_name, body, identifier=identifier)
 
-        serializer = DummySerializer()
-        expected_data = dict(type=serializer.get_type_identifier(t),
-                             body=str(id(body)),
+        expected_data = dict(body=body,
                              condition=condition_name)
 
-        data = t.get_serialization_data(serializer)
+        data = t.get_serialization_data()
         self.assertEqual(expected_data, data)
 
     def test_deserialize(self) -> None:
+        body = DummyPulseTemplate()
         data = dict(
             identifier='foo_loop',
             condition='foo_cond',
-            body='bodyDummyPulse'
+            body=body
         )
 
-        # prepare dependencies for deserialization
-        serializer = DummySerializer()
-        serializer.subelements[data['body']] = DummyPulseTemplate()
-
         # deserialize
-        result = WhileLoopPulseTemplate.deserialize(serializer, **data)
+        result = WhileLoopPulseTemplate.deserialize(**data)
 
         # compare
-        self.assertIs(serializer.subelements[data['body']], result.body)
+        self.assertIs(body, result.body)
         self.assertEqual(data['condition'], result.condition)
         self.assertEqual(data['identifier'], result.identifier)
+
+    def test_get_serialization_data_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="WhileLoopPT does not issue warning for old serialization routines."):
+            body = DummyPulseTemplate()
+            condition_name = 'foo_cond'
+            identifier = 'foo_loop'
+            t = WhileLoopPulseTemplate(condition_name, body, identifier=identifier)
+
+            serializer = DummySerializer()
+            expected_data = dict(body=str(id(body)),
+                                 condition=condition_name)
+
+            data = t.get_serialization_data(serializer)
+            self.assertEqual(expected_data, data)
+
+    def test_deserialize(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="WhileLoopPT does not issue warning for old serialization routines."):
+            data = dict(
+                identifier='foo_loop',
+                condition='foo_cond',
+                body='bodyDummyPulse'
+            )
+
+            # prepare dependencies for deserialization
+            serializer = DummySerializer()
+            serializer.subelements[data['body']] = DummyPulseTemplate()
+
+            # deserialize
+            result = WhileLoopPulseTemplate.deserialize(serializer, **data)
+
+            # compare
+            self.assertIs(serializer.subelements[data['body']], result.body)
+            self.assertEqual(data['condition'], result.condition)
+            self.assertEqual(data['identifier'], result.identifier)
 
 
 class ConditionMissingExceptionTest(unittest.TestCase):

--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -295,47 +295,78 @@ class AtomicMultiChannelPulseTemplateTest(unittest.TestCase):
         wf = pt.build_waveform(parameters, channel_mapping=channel_mapping)
         self.assertIsNone(wf)
 
-    def test_deserialize(self):
+    def test_deserialize(self) -> None:
         sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, parameter_names={'a', 'b'}),
                DummyPulseTemplate(duration='t1', defined_channels={'B'}, parameter_names={'a', 'c'})]
 
-        def deserialization_callback(ident: str):
-            self.assertIn(ident, ('0', '1'))
+        data = dict(subtemplates=sts, parameter_constraints=['a < d'])
 
-            if ident == '0':
-                return 0
-            else:
-                return 1
-
-        serializer = DummySerializer(deserialize_callback=deserialization_callback)
-        serializer.subelements = sts
-
-        data = dict(subtemplates=['0', '1'], parameter_constraints=['a < d'])
-
-        template = AtomicMultiChannelPulseTemplate.deserialize(serializer, **data)
+        template = AtomicMultiChannelPulseTemplate.deserialize(**data)
 
         self.assertIs(template.subtemplates[0], sts[0])
         self.assertIs(template.subtemplates[1], sts[1])
         self.assertEqual(template.parameter_constraints, [ParameterConstraint('a < d')])
 
-    def test_serialize(self):
+    def test_serialize(self) -> None:
         sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, parameter_names={'a', 'b'}),
                DummyPulseTemplate(duration='t1', defined_channels={'B'}, parameter_names={'a', 'c'})]
         constraints = ['a < d']
         template = AtomicMultiChannelPulseTemplate(*sts,
                                                    parameter_constraints=constraints)
 
-        expected_data = dict(subtemplates=['0', '1'], parameter_constraints=['a < d'])
+        expected_data = dict(subtemplates=sts, parameter_constraints=['a < d'])
 
-        def serialize_callback(obj) -> str:
-            self.assertIn(obj, sts)
-            return str(sts.index(obj))
-
-        serializer = DummySerializer(serialize_callback=serialize_callback, identifier_callback=serialize_callback)
-
-        data = template.get_serialization_data(serializer=serializer)
+        data = template.get_serialization_data()
 
         self.assertEqual(expected_data, data)
+
+    def test_deserialize_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="AtomicMultiChannelPT does not issue warning for old serialization routines."):
+            sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, parameter_names={'a', 'b'}),
+                   DummyPulseTemplate(duration='t1', defined_channels={'B'}, parameter_names={'a', 'c'})]
+
+            def deserialization_callback(ident: str):
+                self.assertIn(ident, ('0', '1'))
+
+                if ident == '0':
+                    return 0
+                else:
+                    return 1
+
+            serializer = DummySerializer(deserialize_callback=deserialization_callback)
+            serializer.subelements = sts
+
+            data = dict(subtemplates=['0', '1'], parameter_constraints=['a < d'])
+
+            template = AtomicMultiChannelPulseTemplate.deserialize(serializer, **data)
+
+            self.assertIs(template.subtemplates[0], sts[0])
+            self.assertIs(template.subtemplates[1], sts[1])
+            self.assertEqual(template.parameter_constraints, [ParameterConstraint('a < d')])
+
+    def test_serialize_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="AtomicMultiChannelPT does not issue warning for old serialization routines."):
+            sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, parameter_names={'a', 'b'}),
+                   DummyPulseTemplate(duration='t1', defined_channels={'B'}, parameter_names={'a', 'c'})]
+            constraints = ['a < d']
+            template = AtomicMultiChannelPulseTemplate(*sts,
+                                                       parameter_constraints=constraints)
+
+            expected_data = dict(subtemplates=['0', '1'], parameter_constraints=['a < d'])
+
+            def serialize_callback(obj) -> str:
+                self.assertIn(obj, sts)
+                return str(sts.index(obj))
+
+            serializer = DummySerializer(serialize_callback=serialize_callback, identifier_callback=serialize_callback)
+
+            data = template.get_serialization_data(serializer=serializer)
+
+            self.assertEqual(expected_data, data)
 
     def test_integral(self) -> None:
         sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'},

--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -6,12 +6,12 @@ import numpy
 from qctoolkit.utils.types import time_from_float
 from qctoolkit.pulses.multi_channel_pulse_template import MultiChannelWaveform, MappingPulseTemplate, ChannelMappingException, AtomicMultiChannelPulseTemplate
 from qctoolkit.pulses.parameters import ParameterConstraint, ParameterConstraintViolation
-from qctoolkit.serialization import Serializable
+from qctoolkit.expressions import ExpressionScalar, Expression
 
 from tests.pulses.sequencing_dummies import DummyPulseTemplate, DummyWaveform
 from tests.serialization_dummies import DummySerializer
 from tests.pulses.pulse_template_tests import PulseTemplateStub
-from qctoolkit.expressions import ExpressionScalar
+from tests.serialization_tests import SerializableTests
 
 
 class MultiChannelWaveformTest(unittest.TestCase):
@@ -308,54 +308,30 @@ class AtomicMultiChannelPulseTemplateTest(unittest.TestCase):
                          pulse.integral)
 
 
-class AtomicMultiChannelPulseTemplateSerializationTests(unittest.TestCase):
+class AtomicMultiChannelPulseTemplateSerializationTests(SerializableTests, unittest.TestCase):
 
-    def test_get_serialization_data_with_identifier(self) -> None:
-        sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, parameter_names={'a', 'b'}),
-               DummyPulseTemplate(duration='t1', defined_channels={'B'}, parameter_names={'a', 'c'})]
-        constraints = ['a < d']
-        template = AtomicMultiChannelPulseTemplate(*sts,
-                                                   parameter_constraints=constraints,
-                                                   identifier='foo')
+    @property
+    def class_to_test(self):
+        return AtomicMultiChannelPulseTemplate
 
-        expected_data = {
-            'subtemplates': sts,
-            'parameter_constraints': ['a < d'],
-            Serializable.type_identifier_name: AtomicMultiChannelPulseTemplate.get_type_identifier(),
-            Serializable.identifier_name: 'foo'
+    def make_kwargs(self):
+        return {
+            'subtemplates': [DummyPulseTemplate(duration='t1', defined_channels={'A'}, parameter_names={'a', 'b'}),
+                             DummyPulseTemplate(duration='t1', defined_channels={'B'}, parameter_names={'a', 'c'})],
+            'parameter_constraints': [str(ParameterConstraint('ilse>2')), str(ParameterConstraint('k>foo'))]
         }
 
-        data = template.get_serialization_data()
-        self.assertEqual(expected_data, data)
+    def make_instance(self, identifier=None):
+        kwargs = self.make_kwargs()
+        subtemplates = kwargs['subtemplates']
+        del kwargs['subtemplates']
+        return self.class_to_test(identifier=identifier, *subtemplates, **kwargs)
 
-    def test_get_serialization_data_without_identifier(self) -> None:
-        sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, parameter_names={'a', 'b'}),
-               DummyPulseTemplate(duration='t1', defined_channels={'B'}, parameter_names={'a', 'c'})]
-        constraints = ['a < d']
-        template = AtomicMultiChannelPulseTemplate(*sts,
-                                                   parameter_constraints=constraints)
-
-        expected_data = {
-            'subtemplates': sts,
-            'parameter_constraints': ['a < d'],
-            Serializable.type_identifier_name: AtomicMultiChannelPulseTemplate.get_type_identifier()
-        }
-
-        data = template.get_serialization_data()
-        self.assertEqual(expected_data, data)
-
-    def test_deserialize(self) -> None:
-        sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, parameter_names={'a', 'b'}),
-               DummyPulseTemplate(duration='t1', defined_channels={'B'}, parameter_names={'a', 'c'})]
-
-        data = dict(subtemplates=sts, parameter_constraints=['a < d'], identifier='hugo')
-
-        template = AtomicMultiChannelPulseTemplate.deserialize(**data)
-
-        self.assertIs(template.subtemplates[0], sts[0])
-        self.assertIs(template.subtemplates[1], sts[1])
-        self.assertEqual(template.parameter_constraints, [ParameterConstraint('a < d')])
-        self.assertEqual('hugo', template.identifier)
+    def assert_equal_instance(self, lhs: AtomicMultiChannelPulseTemplate, rhs: AtomicMultiChannelPulseTemplate):
+        self.assertIsInstance(lhs, AtomicMultiChannelPulseTemplate)
+        self.assertIsInstance(rhs, AtomicMultiChannelPulseTemplate)
+        self.assertEqual(lhs.subtemplates, rhs.subtemplates)
+        self.assertEqual(lhs.parameter_constraints, rhs.parameter_constraints)
 
 
 class AtomicMultiChannelPulseTemplateOldSerializationTests(unittest.TestCase):

--- a/tests/pulses/point_pulse_template_tests.py
+++ b/tests/pulses/point_pulse_template_tests.py
@@ -220,13 +220,11 @@ class TablePulseTemplateMeasurementTest(MeasurementDefinerTest):
 
 class PointPulseTemplateSerializationTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.serializer = DummySerializer(lambda x: dict(name=x.name), lambda x: x.name, lambda x: x['name'])
         self.entries = [('foo', 2, 'hold'), ('hugo', 'A + B', 'linear'), ('sudo', [1, 'a'], 'jump')]
         self.measurements = [('m', 1, 1), ('foo', 'z', 'o')]
         self.template = PointPulseTemplate(time_point_tuple_list=self.entries, channel_names=[0, 'A'],
                                            measurements=self.measurements,
                                            identifier='foo', parameter_constraints=['ilse>2', 'k>foo'])
-        self.expected_data = dict(type=self.serializer.get_type_identifier(self.template))
         self.maxDiff = None
 
     def test_get_serialization_data(self) -> None:
@@ -235,7 +233,7 @@ class PointPulseTemplateSerializationTests(unittest.TestCase):
                              channel_names=(0, 'A'),
                              parameter_constraints=[str(Expression('ilse>2')), str(Expression('k>foo'))])
 
-        data = self.template.get_serialization_data(self.serializer)
+        data = self.template.get_serialization_data()
         self.assertEqual(expected_data, data)
 
     def test_deserialize(self) -> None:
@@ -246,18 +244,54 @@ class PointPulseTemplateSerializationTests(unittest.TestCase):
                     identifier='foo')
 
         # deserialize
-        template = PointPulseTemplate.deserialize(self.serializer, **data)
+        template = PointPulseTemplate.deserialize(**data)
 
         self.assertEqual(template.point_pulse_entries, self.template.point_pulse_entries)
         self.assertEqual(template.measurement_declarations, self.template.measurement_declarations)
         self.assertEqual(template.parameter_constraints, self.template.parameter_constraints)
 
-    def test_serializer_integration(self):
-        serializer = Serializer(DummyStorageBackend())
-        serializer.serialize(self.template)
-        template = serializer.deserialize('foo')
+    def test_get_serialization_data_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="PointPT does not issue warning for old serialization routines."):
+            expected_data = dict(measurements=self.measurements,
+                                 time_point_tuple_list=self.entries,
+                                 channel_names=(0, 'A'),
+                                 parameter_constraints=[str(Expression('ilse>2')), str(Expression('k>foo'))])
 
-        self.assertIsInstance(template, PointPulseTemplate)
-        self.assertEqual(template.point_pulse_entries, self.template.point_pulse_entries)
-        self.assertEqual(template.measurement_declarations, self.template.measurement_declarations)
-        self.assertEqual(template.parameter_constraints, self.template.parameter_constraints)
+            serializer = DummySerializer(lambda x: dict(name=x.name), lambda x: x.name, lambda x: x['name'])
+            data = self.template.get_serialization_data(serializer)
+            self.assertEqual(expected_data, data)
+
+    def test_deserialize_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="PointPT does not issue warning for old serialization routines."):
+            data = dict(measurements=self.measurements,
+                        time_point_tuple_list=self.entries,
+                        channel_names=(0, 'A'),
+                        parameter_constraints=['ilse>2', 'k>foo'],
+                        identifier='foo')
+
+            # deserialize
+            serializer = DummySerializer(lambda x: dict(name=x.name), lambda x: x.name, lambda x: x['name'])
+            template = PointPulseTemplate.deserialize(serializer, **data)
+
+            self.assertEqual(template.point_pulse_entries, self.template.point_pulse_entries)
+            self.assertEqual(template.measurement_declarations, self.template.measurement_declarations)
+            self.assertEqual(template.parameter_constraints, self.template.parameter_constraints)
+
+    def test_serializer_integration_old(self):
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="PointPT does not issue warning for old serialization routines."):
+            serializer = Serializer(DummyStorageBackend())
+            serializer.serialize(self.template)
+            template = serializer.deserialize('foo')
+
+            self.assertIsInstance(template, PointPulseTemplate)
+            self.assertEqual(template.point_pulse_entries, self.template.point_pulse_entries)
+            self.assertEqual(template.measurement_declarations, self.template.measurement_declarations)
+            self.assertEqual(template.parameter_constraints, self.template.parameter_constraints)
+
+    # todo: implement full serialization-deserialization test for new routines

--- a/tests/pulses/repetition_pulse_template_tests.py
+++ b/tests/pulses/repetition_pulse_template_tests.py
@@ -232,71 +232,148 @@ class RepetitionPulseTemplateSequencingTests(unittest.TestCase):
 
 class RepetitionPulseTemplateSerializationTests(unittest.TestCase):
 
-    def setUp(self) -> None:
-        self.serializer = DummySerializer(deserialize_callback=lambda x: x['name'])
-        self.body = DummyPulseTemplate()
-
     def test_get_serialization_data_minimal(self) -> None:
+        body = DummyPulseTemplate()
         repetition_count = 3
-        template = RepetitionPulseTemplate(self.body, repetition_count)
+        template = RepetitionPulseTemplate(body, repetition_count)
         expected_data = dict(
-            body=str(id(self.body)),
+            body=body,
             repetition_count=repetition_count,
         )
-        data = template.get_serialization_data(self.serializer)
+        data = template.get_serialization_data()
         self.assertEqual(expected_data, data)
 
     def test_get_serialization_data_all_features(self) -> None:
+        body = DummyPulseTemplate()
         repetition_count = 'foo'
         measurements = [('a', 0, 1), ('b', 1, 1)]
         parameter_constraints = ['foo < 3']
-        template = RepetitionPulseTemplate(self.body, repetition_count,
+        template = RepetitionPulseTemplate(body, repetition_count,
                                            measurements=measurements,
                                            parameter_constraints=parameter_constraints)
         expected_data = dict(
-            body=str(id(self.body)),
+            body=body,
             repetition_count=repetition_count,
             measurements=measurements,
             parameter_constraints=parameter_constraints
         )
-        data = template.get_serialization_data(self.serializer)
+        data = template.get_serialization_data()
         self.assertEqual(expected_data, data)
 
     def test_deserialize_minimal(self) -> None:
+        body = DummyPulseTemplate()
         repetition_count = 3
         data = dict(
             repetition_count=repetition_count,
-            body=dict(name=str(id(self.body))),
+            body=body,
             identifier='foo'
         )
-        # prepare dependencies for deserialization
-        self.serializer.subelements[str(id(self.body))] = self.body
         # deserialize
-        template = RepetitionPulseTemplate.deserialize(self.serializer, **data)
+        template = RepetitionPulseTemplate.deserialize(**data)
         # compare!
-        self.assertIs(self.body, template.body)
+        self.assertIs(body, template.body)
         self.assertEqual(repetition_count, template.repetition_count)
-        #self.assertEqual([str(c) for c in template.parameter_constraints], ['bar < 3'])
 
     def test_deserialize_all_features(self) -> None:
+        body = DummyPulseTemplate()
         data = dict(
             repetition_count='foo',
-            body=dict(name=str(id(self.body))),
+            body=body,
             identifier='foo',
             parameter_constraints=['foo < 3'],
             measurements=[('a', 0, 1), ('b', 1, 1)]
         )
-        # prepare dependencies for deserialization
-        self.serializer.subelements[str(id(self.body))] = self.body
 
         # deserialize
-        template = RepetitionPulseTemplate.deserialize(self.serializer, **data)
+        template = RepetitionPulseTemplate.deserialize(**data)
 
         # compare!
-        self.assertIs(self.body, template.body)
+        self.assertIs(body, template.body)
         self.assertEqual('foo', template.repetition_count)
         self.assertEqual(template.parameter_constraints, [ParameterConstraint('foo < 3')])
         self.assertEqual(template.measurement_declarations, data['measurements'])
+
+    def test_get_serialization_data_minimal_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="RepetitionPT does not issue warning for old serialization routines."):
+            serializer = DummySerializer(deserialize_callback=lambda x: x['name'])
+            body = DummyPulseTemplate()
+            repetition_count = 3
+            template = RepetitionPulseTemplate(body, repetition_count)
+            expected_data = dict(
+                body=str(id(body)),
+                repetition_count=repetition_count,
+            )
+            data = template.get_serialization_data(serializer)
+            self.assertEqual(expected_data, data)
+
+    def test_get_serialization_data_all_features_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="RepetitionPT does not issue warning for old serialization routines."):
+            serializer = DummySerializer(deserialize_callback=lambda x: x['name'])
+            body = DummyPulseTemplate()
+            repetition_count = 'foo'
+            measurements = [('a', 0, 1), ('b', 1, 1)]
+            parameter_constraints = ['foo < 3']
+            template = RepetitionPulseTemplate(body, repetition_count,
+                                               measurements=measurements,
+                                               parameter_constraints=parameter_constraints)
+            expected_data = dict(
+                body=str(id(body)),
+                repetition_count=repetition_count,
+                measurements=measurements,
+                parameter_constraints=parameter_constraints
+            )
+            data = template.get_serialization_data(serializer)
+            self.assertEqual(expected_data, data)
+
+    def test_deserialize_minimal_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="RepetitionPT does not issue warning for old serialization routines."):
+            serializer = DummySerializer(deserialize_callback=lambda x: x['name'])
+            body = DummyPulseTemplate()
+            repetition_count = 3
+            data = dict(
+                repetition_count=repetition_count,
+                body=dict(name=str(id(body))),
+                identifier='foo'
+            )
+            # prepare dependencies for deserialization
+            serializer.subelements[str(id(body))] = body
+            # deserialize
+            template = RepetitionPulseTemplate.deserialize(serializer, **data)
+            # compare!
+            self.assertIs(body, template.body)
+            self.assertEqual(repetition_count, template.repetition_count)
+            #self.assertEqual([str(c) for c in template.parameter_constraints], ['bar < 3'])
+
+    def test_deserialize_all_features_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="RepetitionPT does not issue warning for old serialization routines."):
+            serializer = DummySerializer(deserialize_callback=lambda x: x['name'])
+            body = DummyPulseTemplate()
+            data = dict(
+                repetition_count='foo',
+                body=dict(name=str(id(body))),
+                identifier='foo',
+                parameter_constraints=['foo < 3'],
+                measurements=[('a', 0, 1), ('b', 1, 1)]
+            )
+            # prepare dependencies for deserialization
+            serializer.subelements[str(id(body))] = body
+
+            # deserialize
+            template = RepetitionPulseTemplate.deserialize(serializer, **data)
+
+            # compare!
+            self.assertIs(body, template.body)
+            self.assertEqual('foo', template.repetition_count)
+            self.assertEqual(template.parameter_constraints, [ParameterConstraint('foo < 3')])
+            self.assertEqual(template.measurement_declarations, data['measurements'])
 
     def test_integral(self) -> None:
         dummy = DummyPulseTemplate(integrals=['foo+2', 'k*3+x**2'])

--- a/tests/pulses/repetition_pulse_template_tests.py
+++ b/tests/pulses/repetition_pulse_template_tests.py
@@ -8,11 +8,11 @@ from qctoolkit.pulses.parameters import ParameterNotProvidedException, Parameter
     ParameterConstraint
 from qctoolkit.pulses.instructions import REPJInstruction, InstructionPointer
 from qctoolkit.utils.types import time_from_float
-from qctoolkit.serialization import Serializable
 
 from tests.pulses.sequencing_dummies import DummyPulseTemplate, DummySequencer, DummyInstructionBlock, DummyParameter,\
     DummyCondition, DummyWaveform
 from tests.serialization_dummies import DummySerializer
+from tests.serialization_tests import SerializableTests
 
 
 class RepetitionWaveformTest(unittest.TestCase):
@@ -242,85 +242,26 @@ class RepetitionPulseTemplateSequencingTests(unittest.TestCase):
         self.assertEqual(pt.parameter_names, {'a','c', 'n'})
 
 
-class RepetitionPulseTemplateSerializationTests(unittest.TestCase):
+class RepetitionPulseTemplateSerializationTests(SerializableTests, unittest.TestCase):
 
-    def test_get_serialization_data_minimal_with_identifier(self) -> None:
-        body = DummyPulseTemplate()
-        repetition_count = 3
-        template = RepetitionPulseTemplate(body, repetition_count, identifier='foo')
-        expected_data = {
-            'body': body,
-            'repetition_count': repetition_count,
-            Serializable.type_identifier_name: RepetitionPulseTemplate.get_type_identifier(),
-            Serializable.identifier_name: template.identifier
+    @property
+    def class_to_test(self):
+        return RepetitionPulseTemplate
+
+    def make_kwargs(self):
+        return {
+            'body': DummyPulseTemplate(),
+            'repetition_count': 3,
+            'parameter_constraints': [str(ParameterConstraint('a<b'))],
+            'measurements': [('m', 0, 1)]
         }
-        data = template.get_serialization_data()
-        self.assertEqual(expected_data, data)
 
-    def test_get_serialization_data_minimal_without_identifier(self) -> None:
-        body = DummyPulseTemplate()
-        repetition_count = 3
-        template = RepetitionPulseTemplate(body, repetition_count)
-        expected_data = {
-            'body': body,
-            'repetition_count': repetition_count,
-            Serializable.type_identifier_name: RepetitionPulseTemplate.get_type_identifier()
-        }
-        data = template.get_serialization_data()
-        self.assertEqual(expected_data, data)
-
-    def test_get_serialization_data_all_features(self) -> None:
-        body = DummyPulseTemplate()
-        repetition_count = 'foo'
-        measurements = [('a', 0, 1), ('b', 1, 1)]
-        parameter_constraints = ['foo < 3']
-        template = RepetitionPulseTemplate(body, repetition_count,
-                                           measurements=measurements,
-                                           parameter_constraints=parameter_constraints)
-        expected_data = {
-            'body': body,
-            'repetition_count': repetition_count,
-            'measurements': measurements,
-            'parameter_constraints': parameter_constraints,
-            Serializable.type_identifier_name: RepetitionPulseTemplate.get_type_identifier()
-        }
-        data = template.get_serialization_data()
-        self.assertEqual(expected_data, data)
-
-    def test_deserialize_minimal(self) -> None:
-        body = DummyPulseTemplate()
-        repetition_count = 3
-        data = dict(
-            repetition_count=repetition_count,
-            body=body,
-            identifier='foo'
-        )
-        # deserialize
-        template = RepetitionPulseTemplate.deserialize(**data)
-        # compare!
-        self.assertEqual('foo', template.identifier)
-        self.assertIs(body, template.body)
-        self.assertEqual(repetition_count, template.repetition_count)
-
-    def test_deserialize_all_features(self) -> None:
-        body = DummyPulseTemplate()
-        data = dict(
-            repetition_count='foo',
-            body=body,
-            identifier='foo',
-            parameter_constraints=['foo < 3'],
-            measurements=[('a', 0, 1), ('b', 1, 1)]
-        )
-
-        # deserialize
-        template = RepetitionPulseTemplate.deserialize(**data)
-
-        # compare!
-        self.assertIs(body, template.body)
-        self.assertEqual('foo', template.identifier)
-        self.assertEqual('foo', template.repetition_count)
-        self.assertEqual(template.parameter_constraints, [ParameterConstraint('foo < 3')])
-        self.assertEqual(template.measurement_declarations, data['measurements'])
+    def assert_equal_instance(self, lhs: RepetitionPulseTemplate, rhs: RepetitionPulseTemplate):
+        self.assertIsInstance(lhs, RepetitionPulseTemplate)
+        self.assertIsInstance(rhs, RepetitionPulseTemplate)
+        self.assertEqual(lhs.body, rhs.body)
+        self.assertEqual(lhs.parameter_constraints, rhs.parameter_constraints)
+        self.assertEqual(lhs.measurement_declarations, rhs.measurement_declarations)
 
 
 class RepetitionPulseTemplateOldSerializationTests(unittest.TestCase):

--- a/tests/pulses/sequence_pulse_template_tests.py
+++ b/tests/pulses/sequence_pulse_template_tests.py
@@ -9,11 +9,11 @@ from qctoolkit.pulses.sequence_pulse_template import SequencePulseTemplate, Sequ
 from qctoolkit.pulses.pulse_template_parameter_mapping import MappingPulseTemplate
 from qctoolkit.pulses.parameters import ConstantParameter, ParameterConstraint, ParameterConstraintViolation
 from qctoolkit.pulses.instructions import MEASInstruction
-from qctoolkit.serialization import Serializable
 
 from tests.pulses.sequencing_dummies import DummySequencer, DummyInstructionBlock, DummyPulseTemplate,\
     DummyNoValueParameter, DummyWaveform
 from tests.serialization_dummies import DummySerializer
+from tests.serialization_tests import SerializableTests
 
 
 class SequenceWaveformTest(unittest.TestCase):
@@ -173,63 +173,31 @@ class SequencePulseTemplateTest(unittest.TestCase):
         self.assertEqual({'A': ExpressionScalar('k+2*b+7*(b-f)'), 'B': ExpressionScalar('0.24*f')}, pulse.integral)
 
 
-class SequencePulseTemplateSerializationTests(unittest.TestCase):
+class SequencePulseTemplateSerializationTests(SerializableTests, unittest.TestCase):
 
-    def setUp(self) -> None:
-        self.table_foo = TablePulseTemplate({'default': [('hugo', 2),
-                                                         ('albert', 'voltage')]},
-                                            parameter_constraints=['albert<9.1'],
-                                            measurements=[('mw_foo','hugo','albert')],
-                                            identifier='foo')
+    @property
+    def class_to_test(self):
+        return SequencePulseTemplate
 
-        self.foo_param_mappings = dict(hugo='ilse', albert='albert', voltage='voltage')
-        self.foo_meas_mappings = dict(mw_foo='mw_bar')
-
-    def test_get_serialization_data_with_identifier(self) -> None:
-        dummy1 = DummyPulseTemplate()
-        dummy2 = DummyPulseTemplate()
-
-        sequence = SequencePulseTemplate(dummy1, dummy2, parameter_constraints=['a<b'], measurements=[('m', 0, 1)], identifier='sequeeeence')
-
-        expected_data = {
-            'subtemplates': [dummy1, dummy2],
-            'parameter_constraints': ['a < b'],
-            'measurements': [('m', 0, 1)],
-            Serializable.type_identifier_name: SequencePulseTemplate.get_type_identifier(),
-            Serializable.identifier_name: sequence.identifier
+    def make_kwargs(self):
+        return {
+            'subtemplates': [DummyPulseTemplate(), DummyPulseTemplate()],
+            'parameter_constraints': [str(ParameterConstraint('a<b'))],
+            'measurements': [('m', 0, 1)]
         }
-        data = sequence.get_serialization_data()
-        self.assertEqual(expected_data, data)
 
-    def test_get_serialization_data_without_identifier(self) -> None:
-        dummy1 = DummyPulseTemplate()
-        dummy2 = DummyPulseTemplate()
+    def make_instance(self, identifier=None):
+        kwargs = self.make_kwargs()
+        subtemplates = kwargs['subtemplates']
+        del kwargs['subtemplates']
+        return self.class_to_test(identifier=identifier, *subtemplates, **kwargs)
 
-        sequence = SequencePulseTemplate(dummy1, dummy2, parameter_constraints=['a<b'], measurements=[('m', 0, 1)])
-        expected_data = {
-            'subtemplates': [dummy1, dummy2],
-            'parameter_constraints': ['a < b'],
-            'measurements': [('m', 0, 1)],
-            Serializable.type_identifier_name: SequencePulseTemplate.get_type_identifier(),
-        }
-        data = sequence.get_serialization_data()
-        self.assertEqual(expected_data, data)
-
-    def test_deserialize(self) -> None:
-        dummy1 = DummyPulseTemplate()
-        dummy2 = DummyPulseTemplate()
-
-        data = dict(
-            subtemplates=[dummy1, dummy2],
-            identifier='foo',
-            parameter_constraints=['a < b'],
-            measurements=[('m', 0, 1)]
-        )
-
-        template = SequencePulseTemplate.deserialize(**data)
-        self.assertEqual(template.subtemplates, [dummy1, dummy2])
-        self.assertEqual(template.parameter_constraints, [ParameterConstraint('a<b')])
-        self.assertEqual(template.measurement_declarations, [('m', 0, 1)])
+    def assert_equal_instance(self, lhs: SequencePulseTemplate, rhs: SequencePulseTemplate):
+        self.assertIsInstance(lhs, SequencePulseTemplate)
+        self.assertIsInstance(rhs, SequencePulseTemplate)
+        self.assertEqual(lhs.subtemplates, rhs.subtemplates)
+        self.assertEqual(lhs.parameter_constraints, rhs.parameter_constraints)
+        self.assertEqual(lhs.measurement_declarations, rhs.measurement_declarations)
 
 
 class SequencePulseTemplateOldSerializationTests(unittest.TestCase):

--- a/tests/pulses/sequence_pulse_template_tests.py
+++ b/tests/pulses/sequence_pulse_template_tests.py
@@ -185,41 +185,6 @@ class SequencePulseTemplateSerializationTests(unittest.TestCase):
         self.foo_param_mappings = dict(hugo='ilse', albert='albert', voltage='voltage')
         self.foo_meas_mappings = dict(mw_foo='mw_bar')
 
-    def test_get_serialization_data_old(self) -> None:
-        with warnings.catch_warnings(record=True):
-            dummy1 = DummyPulseTemplate()
-            dummy2 = DummyPulseTemplate()
-
-            sequence = SequencePulseTemplate(dummy1, dummy2, parameter_constraints=['a<b'], measurements=[('m', 0, 1)])
-            serializer = DummySerializer(serialize_callback=lambda x: str(x))
-
-            expected_data = dict(
-                subtemplates=[str(dummy1), str(dummy2)],
-                parameter_constraints=['a < b'],
-                measurements=[('m', 0, 1)]
-            )
-            data = sequence.get_serialization_data(serializer)
-            self.assertEqual(expected_data, data)
-
-    def test_deserialize_old(self) -> None:
-        with warnings.catch_warnings(record=True):
-            dummy1 = DummyPulseTemplate()
-            dummy2 = DummyPulseTemplate()
-
-            serializer = DummySerializer(serialize_callback=lambda x: str(id(x)))
-
-            data = dict(
-                subtemplates=[serializer.dictify(dummy1), serializer.dictify(dummy2)],
-                identifier='foo',
-                parameter_constraints=['a < b'],
-                measurements=[('m', 0, 1)]
-            )
-
-            template = SequencePulseTemplate.deserialize(serializer, **data)
-            self.assertEqual(template.subtemplates, [dummy1, dummy2])
-            self.assertEqual(template.parameter_constraints, [ParameterConstraint('a<b')])
-            self.assertEqual(template.measurement_declarations, [('m', 0, 1)])
-
     def test_get_serialization_data(self) -> None:
         dummy1 = DummyPulseTemplate()
         dummy2 = DummyPulseTemplate()
@@ -249,6 +214,45 @@ class SequencePulseTemplateSerializationTests(unittest.TestCase):
         self.assertEqual(template.subtemplates, [dummy1, dummy2])
         self.assertEqual(template.parameter_constraints, [ParameterConstraint('a<b')])
         self.assertEqual(template.measurement_declarations, [('m', 0, 1)])
+
+    def test_get_serialization_data_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="SequencePT does not issue warning for old serialization routines."):
+            dummy1 = DummyPulseTemplate()
+            dummy2 = DummyPulseTemplate()
+
+            sequence = SequencePulseTemplate(dummy1, dummy2, parameter_constraints=['a<b'], measurements=[('m', 0, 1)])
+            serializer = DummySerializer(serialize_callback=lambda x: str(x))
+
+            expected_data = dict(
+                subtemplates=[str(dummy1), str(dummy2)],
+                parameter_constraints=['a < b'],
+                measurements=[('m', 0, 1)]
+            )
+            data = sequence.get_serialization_data(serializer)
+            self.assertEqual(expected_data, data)
+
+    def test_deserialize_old(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="SequencePT does not issue warning for old serialization routines."):
+            dummy1 = DummyPulseTemplate()
+            dummy2 = DummyPulseTemplate()
+
+            serializer = DummySerializer(serialize_callback=lambda x: str(id(x)))
+
+            data = dict(
+                subtemplates=[serializer.dictify(dummy1), serializer.dictify(dummy2)],
+                identifier='foo',
+                parameter_constraints=['a < b'],
+                measurements=[('m', 0, 1)]
+            )
+
+            template = SequencePulseTemplate.deserialize(serializer, **data)
+            self.assertEqual(template.subtemplates, [dummy1, dummy2])
+            self.assertEqual(template.parameter_constraints, [ParameterConstraint('a<b')])
+            self.assertEqual(template.measurement_declarations, [('m', 0, 1)])
 
 
 class SequencePulseTemplateSequencingTests(SequencePulseTemplateTest):

--- a/tests/pulses/sequence_pulse_template_tests.py
+++ b/tests/pulses/sequence_pulse_template_tests.py
@@ -176,8 +176,6 @@ class SequencePulseTemplateTest(unittest.TestCase):
 class SequencePulseTemplateSerializationTests(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.serializer = DummySerializer()
-
         self.table_foo = TablePulseTemplate({'default': [('hugo', 2),
                                                          ('albert', 'voltage')]},
                                             parameter_constraints=['albert<9.1'],
@@ -187,35 +185,67 @@ class SequencePulseTemplateSerializationTests(unittest.TestCase):
         self.foo_param_mappings = dict(hugo='ilse', albert='albert', voltage='voltage')
         self.foo_meas_mappings = dict(mw_foo='mw_bar')
 
+    def test_get_serialization_data_old(self) -> None:
+        with warnings.catch_warnings(record=True):
+            dummy1 = DummyPulseTemplate()
+            dummy2 = DummyPulseTemplate()
+
+            sequence = SequencePulseTemplate(dummy1, dummy2, parameter_constraints=['a<b'], measurements=[('m', 0, 1)])
+            serializer = DummySerializer(serialize_callback=lambda x: str(x))
+
+            expected_data = dict(
+                subtemplates=[str(dummy1), str(dummy2)],
+                parameter_constraints=['a < b'],
+                measurements=[('m', 0, 1)]
+            )
+            data = sequence.get_serialization_data(serializer)
+            self.assertEqual(expected_data, data)
+
+    def test_deserialize_old(self) -> None:
+        with warnings.catch_warnings(record=True):
+            dummy1 = DummyPulseTemplate()
+            dummy2 = DummyPulseTemplate()
+
+            serializer = DummySerializer(serialize_callback=lambda x: str(id(x)))
+
+            data = dict(
+                subtemplates=[serializer.dictify(dummy1), serializer.dictify(dummy2)],
+                identifier='foo',
+                parameter_constraints=['a < b'],
+                measurements=[('m', 0, 1)]
+            )
+
+            template = SequencePulseTemplate.deserialize(serializer, **data)
+            self.assertEqual(template.subtemplates, [dummy1, dummy2])
+            self.assertEqual(template.parameter_constraints, [ParameterConstraint('a<b')])
+            self.assertEqual(template.measurement_declarations, [('m', 0, 1)])
+
     def test_get_serialization_data(self) -> None:
         dummy1 = DummyPulseTemplate()
         dummy2 = DummyPulseTemplate()
 
         sequence = SequencePulseTemplate(dummy1, dummy2, parameter_constraints=['a<b'], measurements=[('m', 0, 1)])
-        serializer = DummySerializer(serialize_callback=lambda x: str(x))
 
         expected_data = dict(
-            subtemplates=[str(dummy1), str(dummy2)],
+            subtemplates=[dummy1, dummy2],
             parameter_constraints=['a < b'],
             measurements=[('m', 0, 1)]
         )
-        data = sequence.get_serialization_data(serializer)
+        data = sequence.get_serialization_data()
         self.assertEqual(expected_data, data)
 
     def test_deserialize(self) -> None:
         dummy1 = DummyPulseTemplate()
         dummy2 = DummyPulseTemplate()
 
-        serializer = DummySerializer(serialize_callback=lambda x: str(id(x)))
-
         data = dict(
-            subtemplates=[serializer.dictify(dummy1), serializer.dictify(dummy2)],
+            subtemplates=[dummy1, dummy2],
             identifier='foo',
             parameter_constraints=['a < b'],
             measurements=[('m', 0, 1)]
         )
 
-        template = SequencePulseTemplate.deserialize(serializer, **data)
+        template = SequencePulseTemplate.deserialize(**data)
         self.assertEqual(template.subtemplates, [dummy1, dummy2])
         self.assertEqual(template.parameter_constraints, [ParameterConstraint('a<b')])
         self.assertEqual(template.measurement_declarations, [('m', 0, 1)])

--- a/tests/pulses/table_pulse_template_tests.py
+++ b/tests/pulses/table_pulse_template_tests.py
@@ -4,7 +4,7 @@ import warnings
 import numpy
 
 from qctoolkit.expressions import Expression
-from qctoolkit.serialization import Serializer, Serializable
+from qctoolkit.serialization import Serializer, Serializable, PulseStorage
 from qctoolkit.pulses.table_pulse_template import TablePulseTemplate, TableWaveform, TableEntry, TableWaveformEntry, ZeroDurationTablePulseTemplate, AmbiguousTablePulseEntry
 from qctoolkit.pulses.parameters import ParameterNotProvidedException, ParameterConstraintViolation
 from qctoolkit.pulses.interpolation import HoldInterpolationStrategy, LinearInterpolationStrategy, JumpInterpolationStrategy
@@ -495,7 +495,20 @@ class TablePulseTemplateSerializationTests(unittest.TestCase):
         self.assertEqual(template.measurement_declarations, self.template.measurement_declarations)
         self.assertEqual(template.parameter_constraints, self.template.parameter_constraints)
 
-    #todo: add full serialize-deserialize integration test for new serialization routines
+    def test_serializer_integration(self):
+        storage_backend = DummyStorageBackend()
+        pulse_storage = PulseStorage(storage_backend)
+        pulse_storage[self.template.identifier] = self.template
+        pulse_storage.flush()
+
+        pulse_storage = PulseStorage(storage_backend) #recreate object to clear temporary storage
+        template = pulse_storage[self.template.identifier]
+
+        self.assertIsInstance(template, TablePulseTemplate)
+        self.assertEqual('foo', template.identifier)
+        self.assertEqual(self.template.entries, template.entries)
+        self.assertEqual(self.template.measurement_declarations, template.measurement_declarations)
+        self.assertEqual(self.template.parameter_constraints, template.parameter_constraints)
 
 
 class TablePulseTemplateOldSerializationTests(unittest.TestCase):

--- a/tests/serialization_tests.py
+++ b/tests/serialization_tests.py
@@ -6,6 +6,7 @@ import typing
 import json
 
 from unittest import mock
+from abc import ABCMeta, abstractmethod
 
 from tempfile import TemporaryDirectory
 from typing import Optional, Any
@@ -40,21 +41,20 @@ class DummySerializable(Serializable):
         return self.__dict__ == other.__dict__
 
 
-class SerializableTests(unittest.TestCase):
+class SerializableTests(metaclass=ABCMeta):
+
     @property
+    @abstractmethod
     def class_to_test(self):
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def make_kwargs(self):
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def assert_equal_instance(self, lhs, rhs):
-        raise NotImplementedError()
-
-    @classmethod
-    def setUpClass(cls):
-        if cls is SerializableTests:
-            raise unittest.SkipTest
+        pass
 
     def make_instance(self, identifier=None):
         return self.class_to_test(identifier=identifier, **self.make_kwargs())
@@ -97,13 +97,13 @@ class SerializableTests(unittest.TestCase):
         self.assert_equal_instance(instance, other_instance)
 
 
-class DummySerializableTests(SerializableTests):
+class DummySerializableTests(SerializableTests, unittest.TestCase):
     @property
     def class_to_test(self):
         return DummySerializable
 
     def make_kwargs(self):
-        return {'data': 'blubber'}
+        return {'data': 'blubber', 'test_dict': {'foo': 'bar', 'no': 17.3}}
 
     def assert_equal_instance(self, lhs, rhs):
         self.assertEqual(lhs.identifier, rhs.identifier)

--- a/tests/serialization_tests.py
+++ b/tests/serialization_tests.py
@@ -495,6 +495,17 @@ class PulseStorageTests(unittest.TestCase):
 
         self.assertFalse(self.storage.temporary_storage)
 
+    def test_flush_on_destroy_object(self) -> None:
+        instance_1 = DummySerializable(identifier='my_id_1')
+        backend = DummyStorageBackend()
+
+        storage = PulseStorage(backend)
+        storage['my_id_1'] = instance_1
+        self.assertNotIn('my_id_1', backend.stored_items)
+        del storage
+
+        self.assertIn('my_id_1', backend.stored_items)
+
 
 class JSONSerializableDecoderTests(unittest.TestCase):
     def test_filter_serializables(self):

--- a/tests/serialization_tests.py
+++ b/tests/serialization_tests.py
@@ -358,8 +358,8 @@ class PulseStorageTests(unittest.TestCase):
 
     def test_deserialize(self):
         obj = {'my_obj': 'tröt', 'wurst': [12, 3, 4]}
-        self.backend['asd'] = json.dumps(obj)
-        deserialized = self.storage._deserialize('asd')
+        serialized = json.dumps(obj)
+        deserialized = self.storage._deserialize(serialized)
         self.assertEqual(deserialized, obj)
 
     def test_contains(self):
@@ -379,7 +379,7 @@ class PulseStorageTests(unittest.TestCase):
     def test_getitem(self):
         instance = DummySerializable(identifier='my_id')
 
-        self.storage.temporary_storage['asd'] = instance
+        self.storage.temporary_storage['asd'] = PulseStorage.StorageEntry(serialization='foobar', serializable=instance)
 
         self.assertIs(self.storage['asd'], instance)
         with self.assertRaises(KeyError):


### PR DESCRIPTION
All PulseTemplate classes now have get_serialization_data and deserialize methods that are conformant with the new serialization routines (from the base branch) but also maintain compatability to the old routines for a transition period. Tests cover both (old and new) ways.

First step to fully integrate the changes into master. 
Still coming up (in separate pull requests):
- Fixes to tests that currently still use the old serialization routines
- Script to automatically convert old serialized pulses into new format