### PR TITLE
Implementation of #247 (clearing all programs)

### DIFF
--- a/qctoolkit/hardware/awgs/base.py
+++ b/qctoolkit/hardware/awgs/base.py
@@ -84,6 +84,13 @@ class AWG(Comparable):
         """
 
     @abstractmethod
+    def clear(self) -> None:
+        """Removes all programs and waveforms from the AWG.
+
+        Caution: This affects all programs and waveforms on the AWG, not only those uploaded using qc-toolkit!
+        """
+
+    @abstractmethod
     def arm(self, name: Optional[str]) -> None:
         """Load the program 'name' and arm the device for running it. If name is None the awg will "dearm" its current
         program."""

--- a/qctoolkit/hardware/dacs/__init__.py
+++ b/qctoolkit/hardware/dacs/__init__.py
@@ -1,26 +1,6 @@
-from abc import ABCMeta, abstractmethod
-from typing import Dict, Tuple
+from qctoolkit.hardware.dacs.dac_base import *
 
-import numpy
-
-__all__ = ['DAC']
-
-
-class DAC(metaclass=ABCMeta):
-    """Representation of a data acquisition card"""
-
-    @abstractmethod
-    def register_measurement_windows(self, program_name: str, windows: Dict[str, Tuple['numpy.ndarray',
-                                                                                       'numpy.ndarray']]) -> None:
-        """"""
-
-    @abstractmethod
-    def register_operations(self, program_name: str, operations) -> None:
-        """"""
-
-    @abstractmethod
-    def arm_program(self, program_name: str) -> None:
-        """"""
-
-    def delete_program(self, program_name) -> None:
-        """"""
+try:
+    from qctoolkit.hardware.dacs.alazar import *
+except ImportError:
+    pass

--- a/qctoolkit/hardware/dacs/alazar.py
+++ b/qctoolkit/hardware/dacs/alazar.py
@@ -6,7 +6,7 @@ import numpy as np
 from atsaverage.config import ScanlineConfiguration
 from atsaverage.masks import CrossBufferMask, Mask
 
-from qctoolkit.hardware.dacs import DAC
+from qctoolkit.hardware.dacs.dac_base import DAC
 
 
 class AlazarProgram:

--- a/qctoolkit/hardware/dacs/alazar.py
+++ b/qctoolkit/hardware/dacs/alazar.py
@@ -122,6 +122,11 @@ class AlazarCard(DAC):
 
     def delete_program(self, program_name: str) -> None:
         self._registered_programs.pop(program_name)
+        # todo [2018-06-14]: what if program to delete is currently armed?
+
+    def clear(self) -> None:
+        self._registered_programs = dict()
+        self.__armed_program = None
 
     @property
     def mask_prototypes(self) -> Dict[str, Tuple[int, str]]:

--- a/qctoolkit/hardware/dacs/dac_base.py
+++ b/qctoolkit/hardware/dacs/dac_base.py
@@ -1,0 +1,28 @@
+from abc import ABCMeta, abstractmethod
+from typing import Dict, Tuple
+
+import numpy
+
+__all__ = ['DAC']
+
+
+class DAC(metaclass=ABCMeta):
+    """Representation of a data acquisition card"""
+
+    @abstractmethod
+    def register_measurement_windows(self, program_name: str, windows: Dict[str, Tuple['numpy.ndarray',
+                                                                                       'numpy.ndarray']]) -> None:
+        """"""
+
+    @abstractmethod
+    def register_operations(self, program_name: str, operations) -> None:
+        """"""
+
+    @abstractmethod
+    def arm_program(self, program_name: str) -> None:
+        """"""
+
+    @abstractmethod
+    def delete_program(self, program_name) -> None:
+        """"""
+

--- a/qctoolkit/hardware/dacs/dac_base.py
+++ b/qctoolkit/hardware/dacs/dac_base.py
@@ -26,3 +26,9 @@ class DAC(metaclass=ABCMeta):
     def delete_program(self, program_name) -> None:
         """"""
 
+    @abstractmethod
+    def clear(self) -> None:
+        """Clears all registered programs.
+
+        Caution: This affects all programs and waveforms on the AWG, not only those uploaded using qc-toolkit!
+        """

--- a/qctoolkit/hardware/setup.py
+++ b/qctoolkit/hardware/setup.py
@@ -180,6 +180,16 @@ class HardwareSetup:
                 except RuntimeError:
                     warnings.warn("Could not remove Program({}) from DAC({})".format(name, dac))
 
+    def clear_programs(self) -> None:
+        """Clears all programs from all known AWG and DAC devices.
+
+        Does not affect channel configurations or measurement masks set by set_channel or set_measurement."""
+        for awg in self.known_awgs:
+            awg.clear()
+        for dac in self.known_dacs:
+            dac.clear()
+        self._registered_programs = dict()
+
     @property
     def known_awgs(self) -> Set[AWG]:
         return {single_channel.awg

--- a/qctoolkit/hardware/setup.py
+++ b/qctoolkit/hardware/setup.py
@@ -188,7 +188,9 @@ class HardwareSetup:
 
     @property
     def known_dacs(self) -> Set[DAC]:
-        return {dac for dac, _ in self._measurement_map.values()}
+        masks = set.union(*self._measurement_map.values())
+        dacs = {mask.dac for mask in masks}
+        return dacs
 
     def arm_program(self, name: str) -> None:
         """Assert program is in memory. Hardware will wait for trigger event"""

--- a/tests/hardware/dummy_devices.py
+++ b/tests/hardware/dummy_devices.py
@@ -56,15 +56,17 @@ class DummyAWG(AWG):
         super().__init__(identifier="DummyAWG{0}".format(id(self)))
 
         self._programs = {} # contains program names and programs
-        self._waveform_memory = [None for i in range(memory)]
-        self._waveform_indices = {} # dict that maps from waveform hash to memory index
-        self._program_wfs = {} # contains program names and necessary waveforms indices
         self._sample_rate = sample_rate
         self._output_range = output_range
         self._num_channels = num_channels
         self._num_markers = num_markers
         self._channels = ('default',)
         self._armed = None
+
+        # todo [2018-06-14]: The following attributes (and thus the memory argument) are never used. Remove?
+        self._waveform_memory = [None for i in range(memory)]
+        self._waveform_indices = {}  # dict that maps from waveform hash to memory index
+        self._program_wfs = {}  # contains program names and necessary waveforms indices
 
     def upload(self, name, program, channels, markers, voltage_transformation, force=False) -> None:
         if name in self.programs:

--- a/tests/hardware/dummy_devices.py
+++ b/tests/hardware/dummy_devices.py
@@ -30,6 +30,11 @@ class DummyDAC(DAC):
         if program_name in self._measurement_windows:
             self._measurement_windows.pop(program_name)
 
+    def clear(self) -> None:
+        self._measurement_windows = dict()
+        self._operations = dict()
+        self._armed_program = None
+
 
 class DummyAWG(AWG):
     """Dummy AWG for debugging purposes."""
@@ -74,6 +79,9 @@ class DummyAWG(AWG):
     def remove(self, name) -> None:
         if name in self.programs:
             self._programs.pop(name)
+
+    def clear(self) -> None:
+        self._programs = {}
 
     def arm(self, name: str) -> None:
         self._armed = name

--- a/tests/hardware/setup_tests.py
+++ b/tests/hardware/setup_tests.py
@@ -343,3 +343,22 @@ class HardwareSetupTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             setup.register_program('p1', block, lambda: None)
 
+    def test_known_dacs(self) -> None:
+        setup = HardwareSetup()
+        dac1 = DummyDAC()
+        dac2 = DummyDAC()
+        setup.set_measurement('m1', MeasurementMask(dac1, 'mask_1'))
+        setup.set_measurement('m2', MeasurementMask(dac2, 'mask_2'))
+        expected = {dac1, dac2}
+        self.assertEqual(expected, setup.known_dacs)
+
+    def test_known_awgs(self) -> None:
+        setup = HardwareSetup()
+        awg1 = DummyAWG(num_channels=2, num_markers=0)
+        awg2 = DummyAWG(num_channels=0, num_markers=1)
+        setup.set_channel('A', PlaybackChannel(awg1, 0))
+        setup.set_channel('B', PlaybackChannel(awg1, 1))
+        setup.set_channel('M1', MarkerChannel(awg2, 0))
+        expected = {awg1, awg2}
+        self.assertEqual(expected, setup.known_awgs)
+

--- a/tests/hardware/setup_tests.py
+++ b/tests/hardware/setup_tests.py
@@ -362,3 +362,42 @@ class HardwareSetupTests(unittest.TestCase):
         expected = {awg1, awg2}
         self.assertEqual(expected, setup.known_awgs)
 
+    def test_clear_programs(self) -> None:
+        setup = HardwareSetup()
+        awg1 = DummyAWG(num_channels=2, num_markers=0)
+        awg2 = DummyAWG(num_channels=1, num_markers=1)
+        dac1 = DummyDAC()
+        dac2 = DummyDAC()
+        setup.set_channel('A', PlaybackChannel(awg1, 0))
+        setup.set_channel('B', PlaybackChannel(awg1, 1))
+        setup.set_channel('C', PlaybackChannel(awg2, 0))
+        setup.set_channel('M1', MarkerChannel(awg2, 0))
+
+        wf1 = DummyWaveform(duration=1.1, defined_channels={'C'})
+        wf2 = DummyWaveform(duration=7.2, defined_channels={'A'})
+        wf3 = DummyWaveform(duration=3.7, defined_channels={'B', 'C'})
+
+        setup.set_measurement('m1', MeasurementMask(dac1, 'DAC_1'))
+        setup.set_measurement('m2', MeasurementMask(dac2, 'DAC_2'))
+
+        block1 = InstructionBlock()
+        block1.add_instruction_exec(wf1)
+
+        block2 = InstructionBlock()
+        block2.add_instruction_meas([('m1', 0., 1.)])
+        block2.add_instruction_exec(wf2)
+
+        block3 = InstructionBlock()
+        block3.add_instruction_meas([('m2', 2., 3.)])
+        block3.add_instruction_exec(wf3)
+
+        setup.register_program('prog1', block1)
+        setup.register_program('prog2', block2)
+        setup.register_program('prog3', block3)
+
+        self.assertTrue(setup.registered_programs)
+
+        setup.clear_programs()
+
+        self.assertFalse(setup.registered_programs)
+


### PR DESCRIPTION
I implemented this by adding an abstract clear() method to the AWG and DAC classes and a clear_programs() method to HardwareSetup which calls clear() of all known AWG and DAC instances.

The Tabor AWG implementation (TaborChannelPair) already had a clear() method. I think it does exactly what is proposed, but I'm not familiar with the Tabor API, so can someone please have a look and confirm this (@terrorfisch , @pcerf or whoever knows stuff like this).
The Alazar DAC implementation seems to store state on hardware but only keeps a dictionary of registered programs in our local code. The clear() method I implemented just clears this dict. Can someone confirm this is correct behavior?

Should be ready to merge after the above two questions are addressed.