### PR TITLE
Fixed a subtle potential bug in loop_pulse_template_tests test_build_…

### DIFF
--- a/tests/pulses/loop_pulse_template_tests.py
+++ b/tests/pulses/loop_pulse_template_tests.py
@@ -161,13 +161,13 @@ class ForLoopPulseTemplateTest(unittest.TestCase):
         with self.assertWarnsRegex(UserWarning, "constraint on a variable shadowing the loop index",
                                    msg="ForLoopPT did not issue a warning when constraining the loop index"):
             flt = ForLoopPulseTemplate(body=DummyPulseTemplate(parameter_names={'k', 'i'}), loop_index='i',
-                                       loop_range=('a', 'b', 'c',), parameter_constraints=['k>i', 'k<=f'])
+                                       loop_range=('a', 'b', 'c',), parameter_constraints=['k<=f', 'k>i'])
 
         # loop index showing up in parameter_names because it appears in consraints
         self.assertEqual(flt.parameter_names, {'f', 'k', 'a', 'b', 'c', 'i'})
 
         parameters = {'k': ConstantParameter(1), 'a': ConstantParameter(0), 'b': ConstantParameter(2),
-                      'c': ConstantParameter(1), 'f': ConstantParameter(0)}
+                      'c': ConstantParameter(1), 'f': ConstantParameter(2)}
         sequencer = DummySequencer()
         block = DummyInstructionBlock()
 


### PR DESCRIPTION
…sequence_constraint_on_loop_var_exception().

A parameter constraint violation was passed only because of the arbitrary order in which the constraints where specified and the fact that one of them was expected to fail with a ParameterNotProvided exception.