### PR TITLE
Fix (global) pulse registry

### DIFF
--- a/qctoolkit/pulses/function_pulse_template.py
+++ b/qctoolkit/pulses/function_pulse_template.py
@@ -14,7 +14,7 @@ import numpy as np
 import sympy
 
 from qctoolkit.expressions import ExpressionScalar
-from qctoolkit.serialization import Serializer
+from qctoolkit.serialization import Serializer, Serializable
 
 from qctoolkit.utils.types import ChannelID, TimeType, time_from_float
 from qctoolkit.pulses.parameters import Parameter, ParameterConstrainer, ParameterConstraint
@@ -44,7 +44,8 @@ class FunctionPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
                  identifier: Optional[str] = None,
                  *,
                  measurements: Optional[List[MeasurementDeclaration]]=None,
-                 parameter_constraints: Optional[List[Union[str, ParameterConstraint]]]=None) -> None:
+                 parameter_constraints: Optional[List[Union[str, ParameterConstraint]]]=None,
+                 registry: Dict[str, Serializable]=None) -> None:
         """
         Args:
             expression: The function represented by this FunctionPulseTemplate
@@ -60,7 +61,7 @@ class FunctionPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
             parameter_constraints: A list of parameter constraints forwarded to the
                 :class:`~`qctoolkit.pulses.measurement.ParameterConstrainer superclass
         """
-        AtomicPulseTemplate.__init__(self, identifier=identifier, measurements=measurements)
+        AtomicPulseTemplate.__init__(self, identifier=identifier, measurements=measurements, registry=registry)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
 
         self.__expression = ExpressionScalar.make(expression)

--- a/qctoolkit/pulses/loop_pulse_template.py
+++ b/qctoolkit/pulses/loop_pulse_template.py
@@ -24,8 +24,10 @@ __all__ = ['ForLoopPulseTemplate', 'LoopPulseTemplate', 'LoopIndexNotUsedExcepti
 
 class LoopPulseTemplate(PulseTemplate):
     """Base class for loop based pulse templates. This class is still abstract and cannot be instantiated."""
-    def __init__(self, body: PulseTemplate, identifier: Optional[str]=None):
-        super().__init__(identifier=identifier)
+    def __init__(self, body: PulseTemplate,
+                 identifier: Optional[str],
+                 registry: Optional[dict]):
+        super().__init__(identifier=identifier, registry=registry)
         self.__body = body
 
     @property
@@ -109,7 +111,8 @@ class ForLoopPulseTemplate(LoopPulseTemplate, MeasurementDefiner, ParameterConst
                  identifier: Optional[str]=None,
                  *,
                  measurements: Optional[Sequence[MeasurementDeclaration]]=None,
-                 parameter_constraints: Optional[Sequence]=None):
+                 parameter_constraints: Optional[Sequence]=None,
+                 registry: Optional[dict]=None):
         """
         Args:
             body: The loop body. It is expected to have `loop_index` as an parameter
@@ -117,7 +120,7 @@ class ForLoopPulseTemplate(LoopPulseTemplate, MeasurementDefiner, ParameterConst
             loop_range: Range to loop through
             identifier: Used for serialization
         """
-        LoopPulseTemplate.__init__(self, body=body, identifier=identifier)
+        LoopPulseTemplate.__init__(self, body=body, identifier=identifier, registry=registry)
         MeasurementDefiner.__init__(self, measurements=measurements)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
 
@@ -291,7 +294,10 @@ class WhileLoopPulseTemplate(LoopPulseTemplate):
     during execution as long as a certain condition holds.
     """
     
-    def __init__(self, condition: str, body: PulseTemplate, identifier: Optional[str]=None) -> None:
+    def __init__(self, condition: str,
+                 body: PulseTemplate,
+                 identifier: Optional[str]=None,
+                 registry: Optional[dict]=None) -> None:
         """Create a new LoopPulseTemplate instance.
 
         Args:
@@ -301,7 +307,7 @@ class WhileLoopPulseTemplate(LoopPulseTemplate):
                 holds.
             identifier (str): A unique identifier for use in serialization. (optional)
         """
-        super().__init__(body=body, identifier=identifier)
+        super().__init__(body=body, identifier=identifier, registry=registry)
         self._condition = condition
 
     def __str__(self) -> str:

--- a/qctoolkit/pulses/multi_channel_pulse_template.py
+++ b/qctoolkit/pulses/multi_channel_pulse_template.py
@@ -139,8 +139,9 @@ class AtomicMultiChannelPulseTemplate(AtomicPulseTemplate, ParameterConstrainer)
                  external_parameters: Optional[Set[str]]=None,
                  identifier: Optional[str]=None,
                  parameter_constraints: Optional[List]=None,
-                 measurements: Optional[List[MeasurementDeclaration]]=None) -> None:
-        AtomicPulseTemplate.__init__(self, identifier=identifier, measurements=measurements)
+                 measurements: Optional[List[MeasurementDeclaration]]=None,
+                 registry: Optional[dict] = None) -> None:
+        AtomicPulseTemplate.__init__(self, identifier=identifier, measurements=measurements, registry=registry)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
 
         self._subtemplates = [st if isinstance(st, PulseTemplate) else MappingPulseTemplate.from_tuple(st) for st in

--- a/qctoolkit/pulses/point_pulse_template.py
+++ b/qctoolkit/pulses/point_pulse_template.py
@@ -45,9 +45,10 @@ class PointPulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
                  *,
                  parameter_constraints: Optional[List[Union[str, ParameterConstraint]]]=None,
                  measurements: Optional[List[MeasurementDeclaration]]=None,
-                 identifier=None):
+                 identifier: Optional[str]=None,
+                 registry: Optional[dict]=None):
 
-        AtomicPulseTemplate.__init__(self, identifier=identifier, measurements=measurements)
+        AtomicPulseTemplate.__init__(self, identifier=identifier, measurements=measurements, registry=registry)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
 
         self._channels = tuple(channel_names)

--- a/qctoolkit/pulses/pulse_template.py
+++ b/qctoolkit/pulses/pulse_template.py
@@ -42,8 +42,10 @@ class PulseTemplate(Serializable, SequencingElement, metaclass=DocStringABCMeta)
     """
 
     def __init__(self, *,
-                 identifier: Optional[str]) -> None:
-        super().__init__(identifier)
+                 identifier: Optional[str],
+                 registry: Optional[Dict[str, Serializable]]) -> None:
+        super().__init__(identifier=identifier,
+                         registry=registry)
 
     @property
     @abstractmethod
@@ -107,8 +109,9 @@ class AtomicPulseTemplate(PulseTemplate, MeasurementDefiner):
     """
     def __init__(self, *,
                  identifier: Optional[str],
-                 measurements: Optional[List[MeasurementDeclaration]]):
-        PulseTemplate.__init__(self, identifier=identifier)
+                 measurements: Optional[List[MeasurementDeclaration]],
+                 registry: Optional[Dict[str, Serializable]]):
+        PulseTemplate.__init__(self, identifier=identifier, registry=registry)
         MeasurementDefiner.__init__(self, measurements=measurements)
 
     def is_interruptable(self) -> bool:

--- a/qctoolkit/pulses/pulse_template_parameter_mapping.py
+++ b/qctoolkit/pulses/pulse_template_parameter_mapping.py
@@ -29,7 +29,8 @@ class MappingPulseTemplate(PulseTemplate, ParameterConstrainer):
                  measurement_mapping: Optional[Dict[str, str]] = None,
                  channel_mapping: Optional[Dict[ChannelID, ChannelID]] = None,
                  parameter_constraints: Optional[List[str]]=None,
-                 allow_partial_parameter_mapping=False):
+                 allow_partial_parameter_mapping: bool=False,
+                 registry: Optional[dict]=None):
         """Standard constructor for the MappingPulseTemplate.
 
         Mappings that are not specified are defaulted to identity mappings. Channels and measurement names of the
@@ -47,7 +48,7 @@ class MappingPulseTemplate(PulseTemplate, ParameterConstrainer):
         :param parameter_constraints:
         :param allow_partial_parameter_mapping:
         """
-        PulseTemplate.__init__(self, identifier=identifier)
+        PulseTemplate.__init__(self, identifier=identifier, registry=registry)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
 
         if parameter_mapping is None:

--- a/qctoolkit/pulses/repetition_pulse_template.py
+++ b/qctoolkit/pulses/repetition_pulse_template.py
@@ -81,7 +81,8 @@ class RepetitionPulseTemplate(LoopPulseTemplate, ParameterConstrainer, Measureme
                  identifier: Optional[str]=None,
                  *args,
                  parameter_constraints: Optional[List]=None,
-                 measurements: Optional[List[MeasurementDeclaration]]=None
+                 measurements: Optional[List[MeasurementDeclaration]]=None,
+                 registry: Optional[dict]=None
                  ) -> None:
         """Create a new RepetitionPulseTemplate instance.
 
@@ -96,7 +97,7 @@ class RepetitionPulseTemplate(LoopPulseTemplate, ParameterConstrainer, Measureme
         elif args:
             TypeError('RepetitionPulseTemplate expects 3 positional arguments, got ' + str(3 + len(args)))
 
-        LoopPulseTemplate.__init__(self, identifier=identifier, body=body)
+        LoopPulseTemplate.__init__(self, identifier=identifier, body=body, registry=registry)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
         MeasurementDefiner.__init__(self, measurements=measurements)
 

--- a/qctoolkit/pulses/sequence_pulse_template.py
+++ b/qctoolkit/pulses/sequence_pulse_template.py
@@ -113,7 +113,8 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
                  external_parameters: Optional[Union[Iterable[str], Set[str]]]=None,
                  identifier: Optional[str]=None,
                  parameter_constraints: Optional[List[Union[str, Expression]]]=None,
-                 measurements: Optional[List[MeasurementDeclaration]]=None) -> None:
+                 measurements: Optional[List[MeasurementDeclaration]]=None,
+                 registry: Optional[dict]=None) -> None:
         """Create a new SequencePulseTemplate instance.
 
         Requires a (correctly ordered) list of subtemplates in the form
@@ -135,7 +136,7 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
                 SequencePulseTemplate. Deprecated.
             identifier (str): A unique identifier for use in serialization. (optional)
         """
-        PulseTemplate.__init__(self, identifier=identifier)
+        PulseTemplate.__init__(self, identifier=identifier, registry=registry)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
         MeasurementDefiner.__init__(self, measurements=measurements)
 

--- a/qctoolkit/pulses/table_pulse_template.py
+++ b/qctoolkit/pulses/table_pulse_template.py
@@ -172,7 +172,8 @@ class TablePulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
                  *,
                  parameter_constraints: Optional[List[Union[str, ParameterConstraint]]]=None,
                  measurements: Optional[List[MeasurementDeclaration]]=None,
-                 consistency_check=True):
+                 consistency_check: bool=True,
+                 registry: Optional[dict]=None):
         """
         Construct a `TablePulseTemplate` from a dict which maps channels to their entries. By default the consistency
         of the provided entries is checked. There are two static functions for convenience construction: from_array and
@@ -186,7 +187,7 @@ class TablePulseTemplate(AtomicPulseTemplate, ParameterConstrainer):
             measurements: Measurement declaration list that is forwarded to the MeasurementDefiner superclass
             consistency_check: If True the consistency of the times will be checked on construction as far as possible
         """
-        AtomicPulseTemplate.__init__(self, identifier=identifier, measurements=measurements)
+        AtomicPulseTemplate.__init__(self, identifier=identifier, measurements=measurements, registry=registry)
         ParameterConstrainer.__init__(self, parameter_constraints=parameter_constraints)
 
         self._entries = dict((ch, list()) for ch in entries.keys())

--- a/tests/pulses/function_pulse_tests.py
+++ b/tests/pulses/function_pulse_tests.py
@@ -154,7 +154,7 @@ class FunctionPulseOldSerializationTests(FunctionPulseTest):
                                            channel='A',
                                            measurements=self.meas_list,
                                            parameter_constraints=self.constraints,
-                                           identifier='my_tpt')
+                                           identifier='my_tpt', registry=dict())
             serializer = Serializer(DummyStorageBackend())
             serializer.serialize(before)
             after = serializer.deserialize('my_tpt')

--- a/tests/pulses/loop_pulse_template_tests.py
+++ b/tests/pulses/loop_pulse_template_tests.py
@@ -19,6 +19,7 @@ from tests.serialization_tests import SerializableTests
 class DummyLoopPulseTemplate(LoopPulseTemplate):
     pass
 DummyLoopPulseTemplate.__abstractmethods__ = set()
+DummyLoopPulseTemplate.__init__ = lambda self, body: LoopPulseTemplate.__init__(self, body, None, None)
 
 
 class LoopPulseTemplateTests(unittest.TestCase):

--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -321,11 +321,11 @@ class AtomicMultiChannelPulseTemplateSerializationTests(SerializableTests, unitt
             'parameter_constraints': [str(ParameterConstraint('ilse>2')), str(ParameterConstraint('k>foo'))]
         }
 
-    def make_instance(self, identifier=None):
+    def make_instance(self, identifier=None, registry=None):
         kwargs = self.make_kwargs()
         subtemplates = kwargs['subtemplates']
         del kwargs['subtemplates']
-        return self.class_to_test(identifier=identifier, *subtemplates, **kwargs)
+        return self.class_to_test(identifier=identifier, *subtemplates, **kwargs, registry=registry)
 
     def assert_equal_instance(self, lhs: AtomicMultiChannelPulseTemplate, rhs: AtomicMultiChannelPulseTemplate):
         self.assertIsInstance(lhs, AtomicMultiChannelPulseTemplate)

--- a/tests/pulses/point_pulse_template_tests.py
+++ b/tests/pulses/point_pulse_template_tests.py
@@ -251,7 +251,8 @@ class PointPulseTemplateOldSerializationTests(unittest.TestCase):
         self.measurements = [('m', 1, 1), ('foo', 'z', 'o')]
         self.template = PointPulseTemplate(time_point_tuple_list=self.entries, channel_names=[0, 'A'],
                                            measurements=self.measurements,
-                                           identifier='foo', parameter_constraints=['ilse>2', 'k>foo'])
+                                           identifier='foo', parameter_constraints=['ilse>2', 'k>foo'],
+                                           registry=dict())
         self.maxDiff = None
 
     def test_get_serialization_data_old(self) -> None:
@@ -286,6 +287,8 @@ class PointPulseTemplateOldSerializationTests(unittest.TestCase):
             self.assertEqual(template.parameter_constraints, self.template.parameter_constraints)
 
     def test_serializer_integration_old(self):
+        registry = dict()
+
         # test for deprecated version during transition period, remove after final switch
         with self.assertWarnsRegex(DeprecationWarning, "deprecated",
                                    msg="PointPT does not issue warning for old serialization routines."):

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -17,8 +17,9 @@ class PulseTemplateStub(PulseTemplate):
                  defined_channels=None,
                  duration=None,
                  parameter_names=None,
-                 measurement_names=None):
-        super().__init__(identifier=identifier)
+                 measurement_names=None,
+                 registry=None):
+        super().__init__(identifier=identifier, registry=registry)
 
         self._defined_channels = defined_channels
         self._duration = duration
@@ -82,8 +83,9 @@ class AtomicPulseTemplateStub(AtomicPulseTemplate):
         return super().is_interruptable()
 
     def __init__(self, *, waveform: Waveform=None, duration: Expression=None, measurements=None,
-                 identifier: Optional[str]=None) -> None:
-        super().__init__(identifier=identifier, measurements=measurements)
+                 identifier: Optional[str]=None,
+                 registry=None) -> None:
+        super().__init__(identifier=identifier, measurements=measurements, registry=registry)
         self.waveform = waveform
         self._duration = duration
 

--- a/tests/pulses/sequence_pulse_template_tests.py
+++ b/tests/pulses/sequence_pulse_template_tests.py
@@ -186,11 +186,11 @@ class SequencePulseTemplateSerializationTests(SerializableTests, unittest.TestCa
             'measurements': [('m', 0, 1)]
         }
 
-    def make_instance(self, identifier=None):
+    def make_instance(self, identifier=None, registry=None):
         kwargs = self.make_kwargs()
         subtemplates = kwargs['subtemplates']
         del kwargs['subtemplates']
-        return self.class_to_test(identifier=identifier, *subtemplates, **kwargs)
+        return self.class_to_test(identifier=identifier, *subtemplates, **kwargs, registry=registry)
 
     def assert_equal_instance(self, lhs: SequencePulseTemplate, rhs: SequencePulseTemplate):
         self.assertIsInstance(lhs, SequencePulseTemplate)
@@ -207,7 +207,8 @@ class SequencePulseTemplateOldSerializationTests(unittest.TestCase):
                                                          ('albert', 'voltage')]},
                                             parameter_constraints=['albert<9.1'],
                                             measurements=[('mw_foo','hugo','albert')],
-                                            identifier='foo')
+                                            identifier='foo',
+                                            registry=dict())
 
         self.foo_param_mappings = dict(hugo='ilse', albert='albert', voltage='voltage')
         self.foo_meas_mappings = dict(mw_foo='mw_bar')
@@ -219,7 +220,8 @@ class SequencePulseTemplateOldSerializationTests(unittest.TestCase):
             dummy1 = DummyPulseTemplate()
             dummy2 = DummyPulseTemplate()
 
-            sequence = SequencePulseTemplate(dummy1, dummy2, parameter_constraints=['a<b'], measurements=[('m', 0, 1)])
+            sequence = SequencePulseTemplate(dummy1, dummy2, parameter_constraints=['a<b'], measurements=[('m', 0, 1)],
+                                             registry=dict())
             serializer = DummySerializer(serialize_callback=lambda x: str(x))
 
             expected_data = dict(

--- a/tests/pulses/sequencing_dummies.py
+++ b/tests/pulses/sequencing_dummies.py
@@ -298,8 +298,9 @@ class DummyPulseTemplate(AtomicPulseTemplate):
                  measurement_names: Set[str] = set(),
                  measurements: list=list(),
                  integrals: Dict[ChannelID, ExpressionScalar]={'default': ExpressionScalar(0)},
-                 identifier=None) -> None:
-        super().__init__(identifier=identifier, measurements=measurements)
+                 identifier=None,
+                 registry=None) -> None:
+        super().__init__(identifier=identifier, measurements=measurements, registry=registry)
         self.requires_stop_ = requires_stop
         self.requires_stop_arguments = []
 

--- a/tests/pulses/table_pulse_template_tests.py
+++ b/tests/pulses/table_pulse_template_tests.py
@@ -344,7 +344,7 @@ class TablePulseTemplateTest(unittest.TestCase):
         tpt = TablePulseTemplate.from_entry_list([(0, 9, 8, 7, 'hold'),
                                                   (1, 2, 1, 3, 'hold'),
                                                   (4, 1, 2, 3, 'linear')],
-                                                 identifier='tpt')
+                                                 identifier='tpt2')
         self.assertEqual(tpt.entries, entries)
 
         entries = {k: entries[i]
@@ -352,10 +352,10 @@ class TablePulseTemplateTest(unittest.TestCase):
         tpt = TablePulseTemplate.from_entry_list([(0, 9, 8, 7),
                                                   (1, 2, 1, 3, 'hold'),
                                                   (4, 1, 2, 3, 'linear')],
-                                                 identifier='tpt',
+                                                 identifier='tpt3',
                                                  channel_names=['A', 'B', 'C'])
         self.assertEqual(tpt.entries, entries)
-        self.assertEqual(tpt.identifier, 'tpt')
+        self.assertEqual(tpt.identifier, 'tpt3')
 
         entries = {0: [(0, 9, HoldInterpolationStrategy()),
                        (1, 2, HoldInterpolationStrategy()),
@@ -369,7 +369,7 @@ class TablePulseTemplateTest(unittest.TestCase):
         tpt = TablePulseTemplate.from_entry_list([(0, 9, 8, 7),
                                                   (1, 2, 1, 3),
                                                   (4, 1, 2, 3)],
-                                                 identifier='tpt')
+                                                 identifier='tpt4')
         self.assertEqual(tpt.entries, entries)
 
     def test_add_entry_multi_same_time_param(self) -> None:
@@ -473,7 +473,8 @@ class TablePulseTemplateOldSerializationTests(unittest.TestCase):
             self.measurements = [('m', 1, 1), ('foo', 'z', 'o')]
             self.template = TablePulseTemplate(entries=self.entries,
                                                measurements=self.measurements,
-                                               identifier='foo', parameter_constraints=['ilse>2', 'k>foo'])
+                                               identifier='foo', parameter_constraints=['ilse>2', 'k>foo'],
+                                               registry=dict())
             self.expected_data = dict(type=self.serializer.get_type_identifier(self.template))
             self.maxDiff = None
 
@@ -489,6 +490,8 @@ class TablePulseTemplateOldSerializationTests(unittest.TestCase):
             self.assertEqual(expected_data, data)
 
     def test_deserialize_old(self) -> None:
+        registry = dict()
+
         # test for deprecated version during transition period, remove after final switch
         with self.assertWarnsRegex(DeprecationWarning, "deprecated",
                                    msg="TablePT does not issue warning for old serialization routines."):
@@ -498,13 +501,15 @@ class TablePulseTemplateOldSerializationTests(unittest.TestCase):
                         identifier='foo')
 
             # deserialize
-            template = TablePulseTemplate.deserialize(self.serializer, **data)
+            template = TablePulseTemplate.deserialize(self.serializer, **data, registry=registry)
 
             self.assertEqual(template.entries, self.template.entries)
             self.assertEqual(template.measurement_declarations, self.template.measurement_declarations)
             self.assertEqual(template.parameter_constraints, self.template.parameter_constraints)
 
     def test_serializer_integration_old(self):
+        registry = dict()
+
         # test for deprecated version during transition period, remove after final switch
         with self.assertWarnsRegex(DeprecationWarning, "deprecated",
                                    msg="TablePT does not issue warning for old serialization routines."):


### PR DESCRIPTION

- Rename pulse registration to registry
- Include in each pulse init method
- Trigger garbage collection on each pulse initialization.
- Update serialization tests to use dedicated registry dicts
