### PR TITLE
Fixes for new serialization

### DIFF
--- a/qctoolkit/pulses/sequence_pulse_template.py
+++ b/qctoolkit/pulses/sequence_pulse_template.py
@@ -229,7 +229,7 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
 
     @classmethod
     def deserialize(cls,
-                    serializer: Serializer=None,  # compatibility to old serialization routines, deprecated
+                    serializer: Optional[Serializer]=None,  # compatibility to old serialization routines, deprecated
                     **kwargs) -> 'SequencePulseTemplate':
         subtemplates = kwargs['subtemplates']
         del kwargs['subtemplates']

--- a/qctoolkit/serialization.py
+++ b/qctoolkit/serialization.py
@@ -381,7 +381,7 @@ class Serializable(metaclass=SerializableMeta):
         """The (optional) identifier of this Serializable. Either a non-empty string or None."""
         return self.__identifier
 
-    def get_serialization_data(self, serializer: 'Serializer'=None) -> Dict[str, Any]:
+    def get_serialization_data(self, serializer: Optional['Serializer']=None) -> Dict[str, Any]:
         """Return all data relevant for serialization as a dictionary containing only base types.
 
         Implementation hint:
@@ -418,7 +418,7 @@ class Serializable(metaclass=SerializableMeta):
         return "{}.{}".format(cls.__module__, cls.__name__)
 
     @classmethod
-    def deserialize(cls, serializer: 'Serializer'=None, **kwargs) -> 'Serializable':
+    def deserialize(cls, serializer: Optional['Serializer']=None, **kwargs) -> 'Serializable':
         """Reconstruct the Serializable object from a dictionary.
 
         Implementation hint:

--- a/tests/pulses/pulse_template_parameter_mapping_tests.py
+++ b/tests/pulses/pulse_template_parameter_mapping_tests.py
@@ -5,10 +5,12 @@ from qctoolkit.pulses.pulse_template_parameter_mapping import MissingMappingExce
     UnnecessaryMappingException, MappingPulseTemplate,\
     AmbiguousMappingException, MappingCollisionException
 from qctoolkit.pulses.parameters import ParameterNotProvidedException
-from qctoolkit.pulses.parameters import ConstantParameter, ParameterConstraintViolation
+from qctoolkit.pulses.parameters import ConstantParameter, ParameterConstraintViolation, ParameterConstraint
 from qctoolkit.expressions import Expression
 
 from tests.pulses.sequencing_dummies import DummyPulseTemplate, DummySequencer, DummyInstructionBlock
+from tests.serialization_tests import SerializableTests
+from tests.serialization_dummies import DummySerializer
 
 
 class MappingTemplateTests(unittest.TestCase):
@@ -226,3 +228,88 @@ class PulseTemplateParameterMappingExceptionsTests(unittest.TestCase):
         dummy = DummyPulseTemplate()
         exception = UnnecessaryMappingException(dummy, 'foo')
         self.assertIsInstance(str(exception), str)
+
+
+class MappingPulseTemplateSerializationTests(SerializableTests, unittest.TestCase):
+
+    @property
+    def class_to_test(self):
+        return MappingPulseTemplate
+
+    def make_kwargs(self):
+        return {
+            'template': DummyPulseTemplate(defined_channels={'foo'},
+                                           measurement_names={'meas'},
+                                           parameter_names={'hugo', 'herbert', 'ilse'}),
+            'parameter_mapping': {'hugo': Expression('2*k+c'), 'herbert': Expression('c-1.5'), 'ilse': Expression('ilse')},
+            'measurement_mapping': {'meas': 'seam'},
+            'channel_mapping': {'foo': 'default_channel'},
+            'parameter_constraints': [str(ParameterConstraint('c > 0'))]
+        }
+
+    def make_instance(self, identifier=None, registry=None):
+        kwargs = self.make_kwargs()
+        return self.class_to_test(identifier=identifier, **kwargs, allow_partial_parameter_mapping=True, registry=registry)
+
+    def assert_equal_instance(self, lhs: MappingPulseTemplate, rhs: MappingPulseTemplate):
+        self.assertIsInstance(lhs, MappingPulseTemplate)
+        self.assertIsInstance(rhs, MappingPulseTemplate)
+        self.assertEqual(lhs.template, rhs.template)
+        self.assertEqual(lhs.parameter_constraints, rhs.parameter_constraints)
+        self.assertEqual(lhs.channel_mapping, rhs.channel_mapping)
+        self.assertEqual(lhs.measurement_mapping, rhs.measurement_mapping)
+        self.assertEqual(lhs.parameter_mapping, rhs.parameter_mapping)
+
+
+class MappingPulseTemplateOldSerializationTests(unittest.TestCase):
+
+    def test_get_serialization_data(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="SequencePT does not issue warning for old serialization routines."):
+            dummy_pt = DummyPulseTemplate(defined_channels={'foo'},
+                                          measurement_names={'meas'},
+                                          parameter_names={'hugo', 'herbert', 'ilse'})
+            mpt = MappingPulseTemplate(
+                template=dummy_pt,
+                parameter_mapping={'hugo': Expression('2*k+c'), 'herbert': Expression('c-1.5'), 'ilse': Expression('ilse')},
+                measurement_mapping={'meas': 'seam'},
+                channel_mapping={'foo': 'default_channel'},
+                parameter_constraints=[str(ParameterConstraint('c > 0'))]
+            )
+            serializer = DummySerializer()
+            expected_data = {
+                'template': serializer.dictify(dummy_pt),
+                'parameter_mapping': {'hugo': str(Expression('2*k+c')), 'herbert': str(Expression('c-1.5')),
+                                      'ilse': str(Expression('ilse'))},
+                'measurement_mapping': {'meas': 'seam'},
+                'channel_mapping': {'foo': 'default_channel'},
+                'parameter_constraints': [str(ParameterConstraint('c > 0'))]
+            }
+            data = mpt.get_serialization_data(serializer=serializer)
+            self.assertEqual(expected_data, data)
+
+    def test_deserialize(self) -> None:
+        # test for deprecated version during transition period, remove after final switch
+        with self.assertWarnsRegex(DeprecationWarning, "deprecated",
+                                   msg="SequencePT does not issue warning for old serialization routines."):
+            dummy_pt = DummyPulseTemplate(defined_channels={'foo'},
+                                          measurement_names={'meas'},
+                                          parameter_names={'hugo', 'herbert', 'ilse'})
+            serializer = DummySerializer()
+            data = {
+                'template': serializer.dictify(dummy_pt),
+                'parameter_mapping': {'hugo': str(Expression('2*k+c')), 'herbert': str(Expression('c-1.5')),
+                                      'ilse': str(Expression('ilse'))},
+                'measurement_mapping': {'meas': 'seam'},
+                'channel_mapping': {'foo': 'default_channel'},
+                'parameter_constraints': [str(ParameterConstraint('c > 0'))]
+            }
+            deserialized = MappingPulseTemplate.deserialize(serializer=serializer, **data)
+
+            self.assertIsInstance(deserialized, MappingPulseTemplate)
+            self.assertEqual(data['parameter_mapping'], deserialized.parameter_mapping)
+            self.assertEqual(data['channel_mapping'], deserialized.channel_mapping)
+            self.assertEqual(data['measurement_mapping'], deserialized.measurement_mapping)
+            self.assertEqual(data['parameter_constraints'], [str(pc) for pc in deserialized.parameter_constraints])
+            self.assertIs(deserialized.template, dummy_pt)

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -39,11 +39,11 @@ class PulseTemplateStub(PulseTemplate):
             raise NotImplementedError()
         return self._parameter_names
 
-    def get_serialization_data(self, serializer: 'Serializer') -> Dict[str, Any]:
+    def get_serialization_data(self, serializer: Optional['Serializer']=None) -> Dict[str, Any]:
         raise NotImplementedError()
 
     @staticmethod
-    def deserialize(serializer: 'Serializer', **kwargs) -> 'AtomicPulseTemplateStub':
+    def deserialize(serializer: Optional['Serializer']=None, **kwargs) -> 'AtomicPulseTemplateStub':
         raise NotImplementedError()
 
     @property
@@ -105,15 +105,15 @@ class AtomicPulseTemplateStub(AtomicPulseTemplate):
     def parameter_names(self) -> Set[str]:
         raise NotImplementedError()
 
-    def get_serialization_data(self, serializer: 'Serializer') -> Dict[str, Any]:
+    def get_serialization_data(self, serializer: Optional['Serializer']=None) -> Dict[str, Any]:
         raise NotImplementedError()
 
     @property
     def measurement_names(self):
         raise NotImplementedError()
 
-    @staticmethod
-    def deserialize(serializer: 'Serializer', **kwargs) -> 'AtomicPulseTemplateStub':
+    @classmethod
+    def deserialize(cls, serializer: Optional['Serializer']=None, **kwargs) -> 'AtomicPulseTemplateStub':
         raise NotImplementedError()
 
     @property

--- a/tests/pulses/sequencing_dummies.py
+++ b/tests/pulses/sequencing_dummies.py
@@ -32,11 +32,11 @@ class DummyParameter(Parameter):
     def __hash__(self):
         return hash(self.value)
 
-    def get_serialization_data(self, serializer: Serializer) -> None:
+    def get_serialization_data(self, serializer: Optional[Serializer]=None) -> None:
             raise NotImplementedError()
 
-    @staticmethod
-    def deserialize(serializer: Serializer) -> 'DummyParameter':
+    @classmethod
+    def deserialize(cls, serializer: Optional[Serializer]=None) -> 'DummyParameter':
         raise NotImplementedError()
 
 class DummyNoValueParameter(Parameter):
@@ -51,11 +51,11 @@ class DummyNoValueParameter(Parameter):
     def requires_stop(self) -> bool:
         return True
 
-    def get_serialization_data(self, serializer: Serializer) -> None:
+    def get_serialization_data(self, serializer: Optional[Serializer]=None) -> None:
             raise NotImplementedError()
 
-    @staticmethod
-    def deserialize(serializer: Serializer) -> 'DummyParameter':
+    @classmethod
+    def deserialize(cls, serializer: Optional[Serializer]=None) -> 'DummyParameter':
         raise NotImplementedError()
 
     def __hash__(self):
@@ -363,7 +363,7 @@ class DummyPulseTemplate(AtomicPulseTemplate):
         self.requires_stop_arguments.append((parameters,conditions))
         return self.requires_stop_
 
-    def get_serialization_data(self, serializer: 'Serializer'=None) -> Dict[str, Any]:
+    def get_serialization_data(self, serializer: Optional['Serializer']=None) -> Dict[str, Any]:
         data = super().get_serialization_data(serializer=serializer)
         data['requires_stop'] = self.requires_stop_
         data['is_interruptable'] = self.is_interruptable


### PR DESCRIPTION
Fixed:
- MappingPT did not implement the new serialization (and had no dedicated serialization tests)
- Several implementations of get_serialization_data and deserialize in test dummies did not have the update signature and required a Serializer object to be passed as positional parameter