### PR TITLE
Fixed sympy version to 1.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='qctoolkit',
       package_dir={'qctoolkit': 'qctoolkit'},
       packages=packages,
       tests_require=['pytest'],
-      install_requires=['sympy>=1.1.1', 'numpy'] + requires_typing,
+      install_requires=['sympy==1.1.1', 'numpy'] + requires_typing,
       extras_require={
           'testing': ['pytest'],
           'plotting': ['matplotlib'],


### PR DESCRIPTION
Sympy version 1.2 results in syntax errors in tests of vectorized expressions . See issue #302 