### PR TITLE
Increased test coverage for serialization

### DIFF
--- a/qctoolkit/serialization.py
+++ b/qctoolkit/serialization.py
@@ -414,12 +414,12 @@ class Serializable(metaclass=SerializableMeta):
             registry = default_pulse_registry
 
         if self.identifier and registry is not None:
-            if self.identifier in registry:
+            if self.identifier in registry and isinstance(registry, weakref.WeakValueDictionary):
                 # trigger garbage collection in case the registered object isn't referenced anymore
                 gc.collect(2)
 
-                if self.identifier in registry:
-                    raise RuntimeError('Pulse with name already exists', self.identifier)
+            if self.identifier in registry:
+                raise RuntimeError('Pulse with name already exists', self.identifier)
 
             registry[self.identifier] = self
 

--- a/qctoolkit/serialization.py
+++ b/qctoolkit/serialization.py
@@ -326,17 +326,6 @@ class DictBackend(StorageBackend):
         return set(self._cache.keys())
 
 
-def get_type_identifier(obj: Any) -> str:
-    """Return a unique type identifier for any object.
-
-    Args:
-        obj: The object for which to obtain a type identifier.
-    Returns:
-        The type identifier as a string.
-    """
-    return "{}.{}".format(obj.__module__, obj.__class__.__name__)
-
-
 class SerializableMeta(DocStringABCMeta):
     deserialization_callbacks = dict()
 


### PR DESCRIPTION
Closes #294

I looked into coveralls to see which lines/branches are not yet covered by tests.
In particular the case in Serializable.__init__() where a pulse might get registered only after the gc is invoked was not covered. I tried to do this (delete a registered pulse with del while explicitely disabling the automatic gc) but couldn't cause the desired behavior. Are we sure that the invocation of the gc is necessary at that point?
Also, there's the issue of the AnonymousSerializable. It is currently not neatly integrated into the Serializable class tree and should really be (or be an abstract class defining abstract methods).