### PR TITLE
Introduce waveform type that implements linear compensation of crosstalk

### DIFF
--- a/qctoolkit/_program/transformation.py
+++ b/qctoolkit/_program/transformation.py
@@ -1,0 +1,55 @@
+from typing import Mapping, Set
+from abc import abstractmethod
+
+import numpy as np
+import pandas as pd
+
+from qctoolkit import ChannelID
+from qctoolkit.comparable import Comparable
+
+
+class Transformation(Comparable):
+    """Transforms numeric time-voltage values for multiple channels to other time-voltage values. The number and names
+     of input and output channels might differ."""
+
+    @abstractmethod
+    def __call__(self, time: np.ndarray, data: pd.DataFrame) -> pd.DataFrame:
+        """Apply transformation to data
+        Args:
+            time:
+            data:
+
+        Returns:
+
+        """
+
+    @abstractmethod
+    def get_output_channels(self, input_channels: Set[ChannelID]) -> Set[ChannelID]:
+        """Return the channel identifiers"""
+
+
+class LinearTransformation(Transformation):
+    def __init__(self, transformation_matrix: pd.DataFrame):
+        """
+
+        Args:
+            transformation_matrix: columns are input and index are output channels
+        """
+        self._matrix = transformation_matrix
+
+    def __call__(self, time: np.ndarray, data: pd.DataFrame) -> Mapping[ChannelID, np.ndarray]:
+        data_in = pd.DataFrame(data)
+        if data_in.index != self._matrix.columns:
+            raise KeyError()
+
+        return self._matrix @ data_in
+
+    def get_output_channels(self, input_channels: Set[ChannelID]):
+        if input_channels != set(self._matrix.columns):
+            raise KeyError()
+
+        return set(self._matrix.index)
+
+    @property
+    def compare_key(self):
+        return self._matrix.to_dict()

--- a/qctoolkit/_program/transformation.py
+++ b/qctoolkit/_program/transformation.py
@@ -20,7 +20,7 @@ class Transformation(Comparable):
             data:
 
         Returns:
-
+            transformed: A DataFrame that has been transformed with index == output_channels
         """
 
     @abstractmethod
@@ -39,14 +39,14 @@ class LinearTransformation(Transformation):
 
     def __call__(self, time: np.ndarray, data: pd.DataFrame) -> Mapping[ChannelID, np.ndarray]:
         data_in = pd.DataFrame(data)
-        if data_in.index != self._matrix.columns:
-            raise KeyError()
+        if set(data_in.index) != set(self._matrix.columns):
+            raise KeyError('Invalid input channels', set(data_in.index), set(self._matrix.columns))
 
         return self._matrix @ data_in
 
     def get_output_channels(self, input_channels: Set[ChannelID]):
         if input_channels != set(self._matrix.columns):
-            raise KeyError()
+            raise KeyError('Invalid input channels', input_channels, set(self._matrix.columns))
 
         return set(self._matrix.index)
 

--- a/tests/_program/transformation_tests.py
+++ b/tests/_program/transformation_tests.py
@@ -1,0 +1,46 @@
+import unittest
+
+import pandas as pd
+import numpy as np
+
+from qctoolkit._program.transformation import LinearTransformation
+
+
+
+class LinearTransformationTests(unittest.TestCase):
+    def test_compare_key(self):
+        trafo_dict = {'transformed_a': {'a': 1, 'b': -1, 'c': 0}, 'transformed_b': {'a': 1, 'b': 1, 'c': 1}}
+        trafo_matrix = pd.DataFrame(trafo_dict).T
+        trafo = LinearTransformation(trafo_matrix)
+
+        self.assertEqual(trafo_matrix.to_dict(), trafo.compare_key)
+
+    def test_get_output_channels(self):
+        trafo_dict = {'transformed_a': {'a': 1, 'b': -1, 'c': 0}, 'transformed_b': {'a': 1, 'b': 1, 'c': 1}}
+        trafo_matrix = pd.DataFrame(trafo_dict).T
+        trafo = LinearTransformation(trafo_matrix)
+
+        self.assertEqual(trafo.get_output_channels({'a', 'b', 'c'}), {'transformed_a', 'transformed_b'})
+        with self.assertRaisesRegex(KeyError, 'Invalid input channels'):
+            trafo.get_output_channels({'a', 'b'})
+
+    def test_call(self):
+        trafo_dict = {'transformed_a': {'a': 1., 'b': -1., 'c': 0.}, 'transformed_b': {'a': 1., 'b': 1., 'c': 1.}}
+        trafo_matrix = pd.DataFrame(trafo_dict).T
+        trafo = LinearTransformation(trafo_matrix)
+
+        data = (np.arange(12.) + 1).reshape((3, 4))
+        data = pd.DataFrame(data, index=list('abc'))
+
+        transformed = trafo(np.full(4, np.NaN), data)
+
+        expected = np.empty((2, 4))
+        expected[0, :] = data.loc['a'] - data.loc['b']
+        expected[1, :] = np.sum(data.values, axis=0)
+
+        expected = pd.DataFrame(expected, index=['transformed_a', 'transformed_b'])
+
+        pd.testing.assert_frame_equal(expected, transformed)
+
+        with self.assertRaisesRegex(KeyError, 'Invalid input channels'):
+            trafo(np.full(4, np.NaN), data.loc[['a', 'b']])

--- a/tests/pulses/sequencing_dummies.py
+++ b/tests/pulses/sequencing_dummies.py
@@ -1,5 +1,5 @@
 """STANDARD LIBRARY IMPORTS"""
-from typing import Tuple, List, Dict, Optional, Set, Any
+from typing import Tuple, List, Dict, Optional, Set, Any, Union
 import copy
 
 import numpy
@@ -136,7 +136,7 @@ class DummyInstructionBlock(InstructionBlock):
 
 class DummyWaveform(Waveform):
 
-    def __init__(self, duration: float=0, sample_output: numpy.ndarray=None, defined_channels={'A'}) -> None:
+    def __init__(self, duration: float=0, sample_output: Union[numpy.ndarray, dict]=None, defined_channels={'A'}) -> None:
         super().__init__()
         self.duration_ = time_from_float(duration)
         self.sample_output = sample_output
@@ -166,7 +166,10 @@ class DummyWaveform(Waveform):
         if output_array is None:
             output_array = numpy.empty_like(sample_times)
         if self.sample_output is not None:
-            output_array[:] = self.sample_output
+            if isinstance(self.sample_output, dict):
+                output_array[:] = self.sample_output[channel]
+            else:
+                output_array[:] = self.sample_output
         else:
             output_array[:] = sample_times
         return output_array


### PR DESCRIPTION
 - Abstract `Transformation` class with a hopfully general enough interface using pandas
- Linear transformation implementation of said class
- `TransformingWaveform` that applies such a transformation
- `SubsetWaveform` which selects a subset of a `Waveform`s channels. This is needed as `TransformingWaveform` always calculates all channels.

TODO: Add pandas dependency to setup.py

Partially implements #149 