### PR TITLE
Changes to (_internal_)create_program()

### DIFF
--- a/qctoolkit/pulses/mapping_pulse_template.py
+++ b/qctoolkit/pulses/mapping_pulse_template.py
@@ -267,14 +267,16 @@ class MappingPulseTemplate(PulseTemplate, ParameterConstrainer):
                                      channel_mapping=self.get_updated_channel_mapping(channel_mapping),
                                      instruction_block=instruction_block)
 
-    def _internal_create_program(self,
+    def _internal_create_program(self, *,
                                  parameters: Dict[str, Parameter],
                                  measurement_mapping: Dict[str, Optional[str]],
-                                 channel_mapping: Dict[ChannelID, Optional[ChannelID]]) -> Optional[Loop]:
+                                 channel_mapping: Dict[ChannelID, Optional[ChannelID]],
+                                 parent_loop: Loop) -> None:
         # parameters are validated in map_parameters() call, no need to do it here again explicitly
-        return self.template.create_program(parameters=self.map_parameters(parameters),
-                                            measurement_mapping=self.get_updated_measurement_mapping(measurement_mapping),
-                                            channel_mapping=self.get_updated_channel_mapping(channel_mapping))
+        self.template._internal_create_program(parameters=self.map_parameters(parameters),
+                                               measurement_mapping=self.get_updated_measurement_mapping(measurement_mapping),
+                                               channel_mapping=self.get_updated_channel_mapping(channel_mapping),
+                                               parent_loop=parent_loop)
 
     def build_waveform(self,
                        parameters: Dict[str, numbers.Real],

--- a/qctoolkit/pulses/multi_channel_pulse_template.py
+++ b/qctoolkit/pulses/multi_channel_pulse_template.py
@@ -21,7 +21,7 @@ from qctoolkit._program.waveforms import MultiChannelWaveform
 from qctoolkit.pulses.pulse_template import PulseTemplate, AtomicPulseTemplate
 from qctoolkit.pulses.mapping_pulse_template import MappingPulseTemplate, MappingTuple
 from qctoolkit.pulses.parameters import Parameter, ParameterConstrainer
-from qctoolkit.pulses.measurement import MeasurementDeclaration
+from qctoolkit.pulses.measurement import MeasurementDeclaration, MeasurementWindow
 from qctoolkit.expressions import Expression, ExpressionScalar
 
 __all__ = ["AtomicMultiChannelPulseTemplate"]
@@ -85,7 +85,9 @@ class AtomicMultiChannelPulseTemplate(AtomicPulseTemplate, ParameterConstrainer)
 
     @property
     def parameter_names(self) -> Set[str]:
-        return set.union(*(st.parameter_names for st in self._subtemplates)) | self.constrained_parameters
+        return set.union(self.measurement_parameters,
+                         self.constrained_parameters,
+                         *(st.parameter_names for st in self._subtemplates))
 
     @property
     def subtemplates(self) -> Sequence[AtomicPulseTemplate]:
@@ -97,7 +99,7 @@ class AtomicMultiChannelPulseTemplate(AtomicPulseTemplate, ParameterConstrainer)
 
     @property
     def measurement_names(self) -> Set[str]:
-        return set.union(*(st.measurement_names for st in self._subtemplates))
+        return super().measurement_names.union(*(st.measurement_names for st in self._subtemplates))
 
     def build_waveform(self, parameters: Dict[str, numbers.Real],
                        channel_mapping: Dict[ChannelID, Optional[ChannelID]]) -> Optional['MultiChannelWaveform']:
@@ -116,6 +118,16 @@ class AtomicMultiChannelPulseTemplate(AtomicPulseTemplate, ParameterConstrainer)
             return sub_waveforms[0]
         else:
             return MultiChannelWaveform(sub_waveforms)
+
+    def get_measurement_windows(self,
+                                parameters: Dict[str, numbers.Real],
+                                measurement_mapping: Dict[str, Optional[str]]) -> List[MeasurementWindow]:
+        measurements = super().get_measurement_windows(parameters=parameters,
+                                                       measurement_mapping=measurement_mapping)
+        for st in self.subtemplates:
+            measurements.extend(st.get_measurement_windows(parameters=parameters,
+                                                           measurement_mapping=measurement_mapping))
+        return measurements
 
     def requires_stop(self,
                       parameters: Dict[str, Parameter],

--- a/qctoolkit/pulses/pulse_template.py
+++ b/qctoolkit/pulses/pulse_template.py
@@ -118,7 +118,7 @@ class PulseTemplate(Serializable, SequencingElement, metaclass=DocStringABCMeta)
         if parameters is None:
             parameters = dict()
         if measurement_mapping is None:
-            measurement_mapping = dict() # todo (2018-08-02): should not be empty but an identity mapping; requires PT to be a MeasurementDefiner (?)
+            measurement_mapping = {name: name for name in self.measurement_names}
         if channel_mapping is None:
             channel_mapping = dict()
 

--- a/tests/pulses/loop_pulse_template_tests.py
+++ b/tests/pulses/loop_pulse_template_tests.py
@@ -290,6 +290,26 @@ class ForLoopTemplateSequencingTests(MeasurementWindowTestCase):
         self.assertIsNone(program._measurements)
         self.assert_measurement_windows_equal({}, program.get_measurement_windows())
 
+    def test_create_program_body_none(self) -> None:
+        dt = DummyPulseTemplate(parameter_names={'i'}, waveform=None, duration=0,
+                                measurements=[('b', 2, 1)])
+        flt = ForLoopPulseTemplate(body=dt, loop_index='i', loop_range=('a', 'b', 'c'),
+                                   measurements=[('A', 0, 1)], parameter_constraints=['c > 1'])
+
+        parameters = {'a': ConstantParameter(1), 'b': ConstantParameter(4), 'c': ConstantParameter(2)}
+        measurement_mapping = dict(A='B', b='b')
+        channel_mapping = dict(C='D')
+
+        program = Loop()
+        flt._internal_create_program(parameters=parameters,
+                                     measurement_mapping=measurement_mapping,
+                                     channel_mapping=channel_mapping,
+                                     parent_loop=program)
+
+        self.assertEqual(0, len(program.children))
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual([], program.children)
+
     def test_create_program(self) -> None:
         dt = DummyPulseTemplate(parameter_names={'i'}, waveform=DummyWaveform(duration=4.0), duration=4,
                                 measurements=[('b', 2, 1)])
@@ -300,8 +320,6 @@ class ForLoopTemplateSequencingTests(MeasurementWindowTestCase):
         measurement_mapping = dict(A='B', b='b')
         channel_mapping = dict(C='D')
 
-        #children = [Loop(waveform=DummyWaveform(duration=2.0))]
-        #program = Loop(children=children)
         program = Loop()
         flt._internal_create_program(parameters=parameters,
                                      measurement_mapping=measurement_mapping,

--- a/tests/pulses/multi_channel_pulse_template_tests.py
+++ b/tests/pulses/multi_channel_pulse_template_tests.py
@@ -5,15 +5,14 @@ import numpy
 
 from qctoolkit.utils.types import time_from_float
 from qctoolkit.pulses.multi_channel_pulse_template import MultiChannelWaveform, MappingPulseTemplate, ChannelMappingException, AtomicMultiChannelPulseTemplate
-from qctoolkit.pulses.parameters import ParameterConstraint, ParameterConstraintViolation
+from qctoolkit.pulses.parameters import ParameterConstraint, ParameterConstraintViolation, ConstantParameter
 from qctoolkit.expressions import ExpressionScalar, Expression
+from qctoolkit._program.instructions import InstructionBlock
 
 from tests.pulses.sequencing_dummies import DummyPulseTemplate, DummyWaveform
 from tests.serialization_dummies import DummySerializer
 from tests.pulses.pulse_template_tests import PulseTemplateStub
 from tests.serialization_tests import SerializableTests
-
-
 
 
 class AtomicMultiChannelPulseTemplateTest(unittest.TestCase):
@@ -118,7 +117,19 @@ class AtomicMultiChannelPulseTemplateTest(unittest.TestCase):
         sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, parameter_names={'a', 'b'}, measurement_names={'A', 'C'}),
                DummyPulseTemplate(duration='t1', defined_channels={'B'}, parameter_names={'a', 'c'}, measurement_names={'A', 'B'})]
 
-        self.assertEqual(AtomicMultiChannelPulseTemplate(*sts).measurement_names, {'A', 'B', 'C'})
+        self.assertEqual(AtomicMultiChannelPulseTemplate(*sts, measurements=[('D', 1, 2)]).measurement_names,
+                         {'A', 'B', 'C', 'D'})
+
+    def test_parameter_names(self):
+        sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, parameter_names={'a', 'b'},
+                                  measurement_names={'A', 'C'}),
+               DummyPulseTemplate(duration='t1', defined_channels={'B'}, parameter_names={'a', 'c'},
+                                  measurement_names={'A', 'B'})]
+        pt = AtomicMultiChannelPulseTemplate(*sts, measurements=[('D', 'd', 2)], parameter_constraints=['d < e'])
+
+        self.assertEqual(pt.parameter_names,
+                         {'a', 'b', 'c', 'd', 'e'})
+
 
     def test_integral(self) -> None:
         sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'},
@@ -197,6 +208,46 @@ class MultiChannelPulseTemplateSequencingTests(unittest.TestCase):
         sts[0].waveform = None
         wf = pt.build_waveform(parameters, channel_mapping=channel_mapping)
         self.assertIsNone(wf)
+
+    def test_build_sequence(self):
+        wfs = [DummyWaveform(duration=1.1, defined_channels={'A'}), DummyWaveform(duration=1.1, defined_channels={'B'})]
+        sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, waveform=wfs[0], measurements=[('m', 0, 1)]),
+               DummyPulseTemplate(duration='t1', defined_channels={'B'}, waveform=wfs[1]),
+               DummyPulseTemplate(duration='t1', defined_channels={'C'}, waveform=None)]
+
+        pt = AtomicMultiChannelPulseTemplate(*sts, parameter_constraints=['a < b'], measurements=[('n', .1, .2)])
+
+        params = dict(a=ConstantParameter(1.0), b=ConstantParameter(1.1))
+        measurement_mapping = dict(m='foo', n='bar')
+        channel_mapping = {'A': 'A', 'B': 'B', 'C': None}
+
+        block = InstructionBlock()
+        pt.build_sequence(None, parameters=params, conditions={}, measurement_mapping=measurement_mapping,
+                          channel_mapping=channel_mapping, instruction_block=block)
+
+        expected_waveform = MultiChannelWaveform(wfs)
+
+        expected_block = InstructionBlock()
+        measurements = [('bar', .1, .2), ('foo', 0, 1)]
+        expected_block.add_instruction_meas(measurements)
+        expected_block.add_instruction_exec(waveform=expected_waveform)
+
+        self.assertEqual(len(block.instructions), len(expected_block.instructions))
+        self.assertEqual(block.instructions[0].compare_key, expected_block.instructions[0].compare_key)
+        self.assertEqual(block.instructions[1].compare_key, expected_block.instructions[1].compare_key)
+
+    def test_get_measurement_windows(self):
+        wfs = [DummyWaveform(duration=1.1, defined_channels={'A'}), DummyWaveform(duration=1.1, defined_channels={'B'})]
+        sts = [DummyPulseTemplate(duration='t1', defined_channels={'A'}, waveform=wfs[0], measurements=[('m', 0, 1),
+                                                                                                        ('n', 0.3, 0.4)]),
+               DummyPulseTemplate(duration='t1', defined_channels={'B'}, waveform=wfs[1], measurements=[('m', 0.1, .2)])]
+
+        pt = AtomicMultiChannelPulseTemplate(*sts, parameter_constraints=['a < b'], measurements=[('n', .1, .2)])
+
+        measurement_mapping = dict(m='foo', n='bar')
+        expected = [('bar', .1, .2), ('foo', 0, 1), ('bar', .3, .4), ('foo', .1, .2)]
+        meas_windows = pt.get_measurement_windows({}, measurement_mapping)
+        self.assertEqual(expected, meas_windows)
 
 
 class AtomicMultiChannelPulseTemplateSerializationTests(SerializableTests, unittest.TestCase):

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -6,8 +6,9 @@ from qctoolkit.utils.types import ChannelID
 from qctoolkit.expressions import Expression, ExpressionScalar
 from qctoolkit.pulses.pulse_template import AtomicPulseTemplate, PulseTemplate
 from qctoolkit._program.instructions import Waveform, EXECInstruction, MEASInstruction
-from qctoolkit.pulses.parameters import Parameter, ConstantParameter
+from qctoolkit.pulses.parameters import Parameter, ConstantParameter, ParameterNotProvidedException
 from qctoolkit.pulses.multi_channel_pulse_template import MultiChannelWaveform
+from qctoolkit._program._loop import Loop
 
 from tests.pulses.sequencing_dummies import DummyWaveform, DummySequencer, DummyInstructionBlock
 
@@ -63,12 +64,14 @@ class PulseTemplateStub(PulseTemplate):
                        instruction_block: 'InstructionBlock'):
         raise NotImplementedError()
 
-    def _internal_create_program(self,
+    def _internal_create_program(self, *,
                                  parameters: Dict[str, Parameter],
                                  measurement_mapping: Dict[str, Optional[str]],
-                                 channel_mapping: Dict[ChannelID, Optional[ChannelID]]) -> Optional['Loop']:
+                                 channel_mapping: Dict[ChannelID, Optional[ChannelID]],
+                                 parent_loop: 'Loop') -> None:
         self.internal_create_program_args.append((parameters, measurement_mapping, channel_mapping))
-        return None
+        if 'append_a_child' in parameters:
+            parent_loop.append_child(Loop(waveform=DummyWaveform()))
 
     def is_interruptable(self):
         raise NotImplementedError()
@@ -146,14 +149,26 @@ class PulseTemplateTest(unittest.TestCase):
 
     def test_create_program(self) -> None:
         template = PulseTemplateStub(defined_channels={'A'}, parameter_names={'foo'})
+        parameters = {'foo': ConstantParameter(2.126), 'bar': -26.2, 'hugo': '2*x+b', 'append_a_child': '1'}
+        measurement_mapping = {'M': 'N'}
+        channel_mapping = {'B': 'A'}
+        program = template.create_program(parameters=parameters,
+                                          measurement_mapping=measurement_mapping,
+                                          channel_mapping=channel_mapping)
+        expected_parameters = {'foo': ConstantParameter(2.126), 'bar': ConstantParameter(-26.2), 'hugo': ConstantParameter('2*x+b'), 'append_a_child': ConstantParameter('1')}
+        self.assertEqual((expected_parameters, measurement_mapping, channel_mapping), template.internal_create_program_args[-1])
+        self.assertIsNotNone(program)
+
+    def test_create_program_none(self) -> None:
+        template = PulseTemplateStub(defined_channels={'A'}, parameter_names={'foo'})
         parameters = {'foo': ConstantParameter(2.126), 'bar': -26.2, 'hugo': '2*x+b'}
         measurement_mapping = {'M': 'N'}
         channel_mapping = {'B': 'A'}
-        template.create_program(parameters=parameters,
-                                measurement_mapping=measurement_mapping,
-                                channel_mapping=channel_mapping)
+        program = template.create_program(parameters=parameters, measurement_mapping=measurement_mapping, channel_mapping=channel_mapping)
         expected_parameters = {'foo': ConstantParameter(2.126), 'bar': ConstantParameter(-26.2), 'hugo': ConstantParameter('2*x+b')}
-        self.assertEqual((expected_parameters, measurement_mapping, channel_mapping), template.internal_create_program_args[-1])
+        self.assertEqual((expected_parameters, measurement_mapping, channel_mapping),
+                         template.internal_create_program_args[-1])
+        self.assertIsNone(program)
 
 
 class AtomicPulseTemplateTests(unittest.TestCase):
@@ -201,11 +216,51 @@ class AtomicPulseTemplateTests(unittest.TestCase):
         template = AtomicPulseTemplateStub(waveform=wf, measurements=measurement_windows, parameter_names={'foo'})
         parameters = {'foo': ConstantParameter(7.2)}
         channel_mapping = {'B': 'A'}
-        program = template._internal_create_program(parameters=parameters,
-                                                    measurement_mapping={'M': 'N'},
-                                                    channel_mapping=channel_mapping)
+        program = Loop()
+        template._internal_create_program(parameters=parameters,
+                                          measurement_mapping={'M': 'N'},
+                                          channel_mapping=channel_mapping,
+                                          parent_loop=program)
         self.assertEqual({k: p.get_value() for k, p in parameters.items()}, template.retrieved_parameters[-1])
         self.assertIs(channel_mapping, template.retrieved_channel_mapping[-1])
         expected_measurement_windows = {'N': (0, 5)}
-        self.assertIs(program.waveform, wf)
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual(1, program.children[0].repetition_count)
+        self.assertIs(program.children[0].waveform, wf)
         self.assertEqual(expected_measurement_windows, program.get_measurement_windows())
+
+    def test_internal_create_program_invalid_measurement_mapping(self) -> None:
+        measurement_windows = [('M', 0, 5)]
+        wf = DummyWaveform(duration=6, defined_channels={'A'})
+
+        template = AtomicPulseTemplateStub(waveform=wf, measurements=measurement_windows, parameter_names={'foo'})
+        parameters = {'foo': ConstantParameter(7.2)}
+        program = Loop()
+        with self.assertRaises(KeyError):
+            template._internal_create_program(parameters=parameters,
+                                              measurement_mapping=dict(),
+                                              channel_mapping=dict(),
+                                              parent_loop=program)
+
+    def test_internal_create_program_missing_parameters(self) -> None:
+        measurement_windows = [('M', 'z', 5)]
+        wf = DummyWaveform(duration=6, defined_channels={'A'})
+
+        template = AtomicPulseTemplateStub(waveform=wf, measurements=measurement_windows, parameter_names={'foo'})
+
+        program = Loop()
+        # test parameter from declarations
+        parameters = {}
+        with self.assertRaises(ParameterNotProvidedException):
+            template._internal_create_program(parameters=parameters,
+                                              measurement_mapping=dict(),
+                                              channel_mapping=dict(),
+                                              parent_loop=program)
+        # test parameter from measurements
+        parameters = {'foo': ConstantParameter(7.2)}
+        with self.assertRaises(ParameterNotProvidedException):
+            template._internal_create_program(parameters=parameters,
+                                              measurement_mapping=dict(),
+                                              channel_mapping=dict(),
+                                              parent_loop=program)
+

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -155,8 +155,24 @@ class PulseTemplateTest(unittest.TestCase):
         program = template.create_program(parameters=parameters,
                                           measurement_mapping=measurement_mapping,
                                           channel_mapping=channel_mapping)
-        expected_parameters = {'foo': ConstantParameter(2.126), 'bar': ConstantParameter(-26.2), 'hugo': ConstantParameter('2*x+b'), 'append_a_child': ConstantParameter('1')}
-        self.assertEqual((expected_parameters, measurement_mapping, channel_mapping), template.internal_create_program_args[-1])
+        expected_parameters = {'foo': ConstantParameter(2.126), 'bar': ConstantParameter(-26.2),
+                               'hugo': ConstantParameter('2*x+b'), 'append_a_child': ConstantParameter('1')}
+        self.assertEqual((expected_parameters, measurement_mapping, channel_mapping),
+                         template.internal_create_program_args[-1])
+        self.assertIsNotNone(program)
+
+    def test_create_program_measurement_mapping_none(self) -> None:
+        template = PulseTemplateStub(defined_channels={'A'}, parameter_names={'foo'}, measurement_names={'hugo', 'foo'})
+        parameters = {'foo': ConstantParameter(2.126), 'bar': -26.2, 'hugo': '2*x+b', 'append_a_child': '1'}
+        measurement_mapping = None
+        channel_mapping = {'B': 'A'}
+        program = template.create_program(parameters=parameters,
+                                          measurement_mapping=measurement_mapping,
+                                          channel_mapping=channel_mapping)
+        expected_parameters = {'foo': ConstantParameter(2.126), 'bar': ConstantParameter(-26.2),
+                               'hugo': ConstantParameter('2*x+b'), 'append_a_child': ConstantParameter('1')}
+        self.assertEqual((expected_parameters, {'hugo': 'hugo', 'foo': 'foo'}, channel_mapping),
+                         template.internal_create_program_args[-1])
         self.assertIsNotNone(program)
 
     def test_create_program_none(self) -> None:
@@ -164,8 +180,11 @@ class PulseTemplateTest(unittest.TestCase):
         parameters = {'foo': ConstantParameter(2.126), 'bar': -26.2, 'hugo': '2*x+b'}
         measurement_mapping = {'M': 'N'}
         channel_mapping = {'B': 'A'}
-        program = template.create_program(parameters=parameters, measurement_mapping=measurement_mapping, channel_mapping=channel_mapping)
-        expected_parameters = {'foo': ConstantParameter(2.126), 'bar': ConstantParameter(-26.2), 'hugo': ConstantParameter('2*x+b')}
+        program = template.create_program(parameters=parameters,
+                                          measurement_mapping=measurement_mapping,
+                                          channel_mapping=channel_mapping)
+        expected_parameters = {'foo': ConstantParameter(2.126), 'bar': ConstantParameter(-26.2),
+                               'hugo': ConstantParameter('2*x+b')}
         self.assertEqual((expected_parameters, measurement_mapping, channel_mapping),
                          template.internal_create_program_args[-1])
         self.assertIsNone(program)

--- a/tests/pulses/repetition_pulse_template_tests.py
+++ b/tests/pulses/repetition_pulse_template_tests.py
@@ -1,8 +1,6 @@
 import unittest
 import warnings
 
-import numpy as np
-
 from qctoolkit._program._loop import Loop
 from qctoolkit.expressions import Expression
 from qctoolkit.pulses.repetition_pulse_template import RepetitionPulseTemplate,ParameterNotIntegerException, RepetitionWaveform
@@ -12,12 +10,9 @@ from qctoolkit._program.instructions import REPJInstruction, InstructionPointer
 from qctoolkit.utils.types import time_from_float
 
 from tests.pulses.sequencing_dummies import DummyPulseTemplate, DummySequencer, DummyInstructionBlock, DummyParameter,\
-    DummyCondition, DummyWaveform
+    DummyCondition, DummyWaveform, MeasurementWindowTestCase
 from tests.serialization_dummies import DummySerializer
 from tests.serialization_tests import SerializableTests
-
-
-
 
 
 class RepetitionPulseTemplateTest(unittest.TestCase):
@@ -97,61 +92,108 @@ class RepetitionPulseTemplateTest(unittest.TestCase):
         self.assertEqual(pt.parameter_names, {'a','c', 'n'})
 
 
-class RepetitionPulseTemplateSequencingTests(unittest.TestCase):
+class RepetitionPulseTemplateSequencingTests(MeasurementWindowTestCase):
 
-    def test_create_program_constant(self) -> None:
+    def test_create_program_constant_success_measurements(self) -> None:
         repetitions = 3
-        body_program = Loop(waveform=DummyWaveform(duration=1.0))
-        body = DummyPulseTemplate(duration=2.0, program=body_program)
-        t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'])
+        body = DummyPulseTemplate(duration=2.0, waveform=DummyWaveform(duration=2), measurements=[('b', 0, 1)])
+        t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'], measurements=[('my', 2, 2)])
         parameters = {'foo': 8}
-        measurement_mapping = {'my': 'thy'}
+        measurement_mapping = {'my': 'thy', 'b': 'b'}
         channel_mapping = {}
-        program = t.create_program(parameters=parameters,
+        program = Loop()
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
 
-        self.assertEqual(repetitions, program.repetition_count)
-        self.assertEqual((parameters, measurement_mapping, channel_mapping), body.create_program_calls[-1])
-        self.assertEqual([body_program], program.children)
-        self.assertEqual([], program._measurements)
+        self.assertEqual(1, len(program.children))
+        internal_loop = program.children[0] # type: Loop
+        self.assertEqual(repetitions, internal_loop.repetition_count)
+
+        self.assertEqual(1, len(internal_loop))
+        self.assertEqual((parameters, measurement_mapping, channel_mapping, internal_loop), body.create_program_calls[-1])
+        self.assertEqual(body.waveform, internal_loop[0].waveform)
+
+        self.assert_measurement_windows_equal({'b': ([0, 2, 4], [1, 1, 1]), 'thy': ([2], [2])}, program.get_measurement_windows())
 
     def test_create_program_declaration_success(self) -> None:
         repetitions = "foo"
-        body_program = Loop(waveform=DummyWaveform(duration=1.0))
-        body = DummyPulseTemplate(duration=2.0, program=body_program)
+        body = DummyPulseTemplate(duration=2.0, waveform=DummyWaveform(duration=2))
         t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'])
         parameters = dict(foo=ConstantParameter(3))
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
-        program = t.create_program(parameters=parameters,
+        program = Loop()
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
 
-        self.assertEqual(parameters[repetitions].get_value(), program.repetition_count)
-        self.assertEqual((parameters, measurement_mapping, channel_mapping),
-                         body.create_program_calls[-1])
-        self.assertEqual([body_program], program.children)
-        self.assertEqual([], program._measurements)
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual(1, len(program.children))
+        internal_loop = program.children[0]  # type: Loop
+        self.assertEqual(parameters[repetitions].get_value(), internal_loop.repetition_count)
+
+        self.assertEqual(1, len(internal_loop))
+        self.assertEqual((parameters, measurement_mapping, channel_mapping, internal_loop), body.create_program_calls[-1])
+        self.assertEqual(body.waveform, internal_loop[0].waveform)
+
+        self.assert_measurement_windows_equal({}, program.get_measurement_windows())
+
+    def test_create_program_declaration_success_appended_measurements(self) -> None:
+        repetitions = "foo"
+        body = DummyPulseTemplate(duration=2.0, waveform=DummyWaveform(duration=2), measurements=[('b', 0, 1)])
+        t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'], measurements=[('moth', 0, 'meas_end')])
+        parameters = dict(foo=ConstantParameter(3), meas_end=ConstantParameter(7.1))
+        measurement_mapping = dict(moth='fire', b='b')
+        channel_mapping = dict(asd='f')
+
+        children = [Loop(waveform=DummyWaveform(duration=0))]
+        program = Loop(children=children, measurements=[('a', [0], [1])], repetition_count=2)
+
+        t._internal_create_program(parameters=parameters,
+                                   measurement_mapping=measurement_mapping,
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
+
+        self.assertEqual(2, program.repetition_count)
+        self.assertEqual(2, len(program.children))
+        self.assertIs(program.children[0], children[0])
+        internal_loop = program.children[1]  # type: Loop
+        self.assertEqual(parameters[repetitions].get_value(), internal_loop.repetition_count)
+
+        self.assertEqual(1, len(internal_loop))
+        self.assertEqual((parameters, measurement_mapping, channel_mapping, internal_loop), body.create_program_calls[-1])
+        self.assertEqual(body.waveform, internal_loop[0].waveform)
+
+        self.assert_measurement_windows_equal({'fire': ([0, 6], [7.1, 7.1]),
+                                         'b': ([0, 2, 4, 6, 8, 10], [1, 1, 1, 1, 1, 1]),
+                                         'a': ([0], [1])}, program.get_measurement_windows())
 
     def test_create_program_declaration_success_measurements(self) -> None:
         repetitions = "foo"
-        body_program = Loop(waveform=DummyWaveform(duration=10.0))
-        body = DummyPulseTemplate(duration=2.0, program=body_program)
+        body = DummyPulseTemplate(duration=2.0, waveform=DummyWaveform(duration=2), measurements=[('b', 0, 1)])
         t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'], measurements=[('moth', 0, 'meas_end')])
         parameters = dict(foo=ConstantParameter(3), meas_end=ConstantParameter(7.1))
-        measurement_mapping = dict(moth='fire')
+        measurement_mapping = dict(moth='fire', b='b')
         channel_mapping = dict(asd='f')
-        program = t.create_program(parameters=parameters,
+        program = Loop()
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
 
-        self.assertEqual(parameters[repetitions].get_value(), program.repetition_count)
-        self.assertEqual((parameters, measurement_mapping, channel_mapping),
-                         body.create_program_calls[-1])
-        self.assertEqual([body_program], program.children)
-        self.assertEqual([('fire', 0, 7.1)], program._measurements)
-        self.assertEqual([{'fire': (0, 7.1)}], program.get_measurement_windows())
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual(1, len(program.children))
+        internal_loop = program.children[0]  # type: Loop
+        self.assertEqual(parameters[repetitions].get_value(), internal_loop.repetition_count)
+
+        self.assertEqual(1, len(internal_loop))
+        self.assertEqual((parameters, measurement_mapping, channel_mapping, internal_loop), body.create_program_calls[-1])
+        self.assertEqual(body.waveform, internal_loop[0].waveform)
+
+        self.assert_measurement_windows_equal({'fire': ([0], [7.1]), 'b': ([0, 2, 4], [1, 1, 1])}, program.get_measurement_windows())
 
     def test_create_program_declaration_exceeds_bounds(self) -> None:
         repetitions = "foo"
@@ -161,39 +203,95 @@ class RepetitionPulseTemplateSequencingTests(unittest.TestCase):
         parameters = dict(foo=ConstantParameter(9))
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
+
+        children = [Loop(waveform=DummyWaveform(duration=0))]
+        program = Loop(children=children)
         with self.assertRaises(ParameterConstraintViolation):
-            t.create_program(parameters=parameters,
-                             measurement_mapping=measurement_mapping,
-                             channel_mapping=channel_mapping)
+            t._internal_create_program(parameters=parameters,
+                                       measurement_mapping=measurement_mapping,
+                                       channel_mapping=channel_mapping,
+                                       parent_loop=program)
         self.assertFalse(body.create_program_calls)
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual(children, program.children)
+        self.assertIsNone(program.waveform)
+        self.assert_measurement_windows_equal({}, program.get_measurement_windows())
 
     def test_create_program_declaration_parameter_not_provided(self) -> None:
         repetitions = "foo"
-        body_program = Loop(waveform=DummyWaveform(duration=1.0))
-        body = DummyPulseTemplate(duration=2.0, program=body_program)
-        t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'])
+        body = DummyPulseTemplate(waveform=DummyWaveform(duration=2.0))
+        t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'], measurements=[('a', 'd', 1)])
         parameters = {}
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
+        children = [Loop(waveform=DummyWaveform(duration=0))]
+        program = Loop(children=children)
         with self.assertRaises(ParameterNotProvidedException):
-            t.create_program(parameters=parameters,
-                             measurement_mapping=measurement_mapping,
-                             channel_mapping=channel_mapping)
+            t._internal_create_program(parameters=parameters,
+                                       measurement_mapping=measurement_mapping,
+                                       channel_mapping=channel_mapping,
+                                       parent_loop=program)
+
+        parameters = {'foo': ConstantParameter(7)}
+        with self.assertRaises(ParameterNotProvidedException):
+            t._internal_create_program(parameters=parameters,
+                                       measurement_mapping=measurement_mapping,
+                                       channel_mapping=channel_mapping,
+                                       parent_loop=program)
+
         self.assertFalse(body.create_program_calls)
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual(children, program.children)
+        self.assertIsNone(program.waveform)
+        self.assert_measurement_windows_equal({}, program.get_measurement_windows())
 
     def test_create_program_declaration_parameter_value_not_whole(self) -> None:
         repetitions = "foo"
-        body_program = Loop(waveform=DummyWaveform(duration=1.0))
-        body = DummyPulseTemplate(duration=2.0, program=body_program)
+        body = DummyPulseTemplate(duration=2.0, waveform=DummyWaveform(duration=2.0))
         t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'])
         parameters = dict(foo=ConstantParameter(3.3))
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
+        children = [Loop(waveform=DummyWaveform(duration=0))]
+        program = Loop(children=children)
         with self.assertRaises(ParameterNotIntegerException):
-            t.create_program(parameters=parameters,
-                            measurement_mapping=measurement_mapping,
-                            channel_mapping=channel_mapping)
+            t._internal_create_program(parameters=parameters,
+                                       measurement_mapping=measurement_mapping,
+                                       channel_mapping=channel_mapping,
+                                       parent_loop=program)
         self.assertFalse(body.create_program_calls)
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual(children, program.children)
+        self.assertIsNone(program.waveform)
+        self.assert_measurement_windows_equal({}, program.get_measurement_windows())
+
+    def test_create_program_constant_measurement_mapping_failure(self) -> None:
+        repetitions = "foo"
+        body = DummyPulseTemplate(duration=2.0, waveform=DummyWaveform(duration=2.0), measurements=[('b', 0, 1)])
+        t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'], measurements=[('a', 0, 1)])
+        parameters = dict(foo=ConstantParameter(3))
+        measurement_mapping = dict()
+        channel_mapping = dict(asd='f')
+        children = [Loop(waveform=DummyWaveform(duration=0))]
+        program = Loop(children=children)
+        with self.assertRaises(KeyError):
+            t._internal_create_program(parameters=parameters,
+                                       measurement_mapping=measurement_mapping,
+                                       channel_mapping=channel_mapping,
+                                       parent_loop=program)
+
+        # test for failure on child level
+        measurement_mapping = dict(a='a')
+        with self.assertRaises(KeyError):
+            t._internal_create_program(parameters=parameters,
+                                       measurement_mapping=measurement_mapping,
+                                       channel_mapping=channel_mapping,
+                                       parent_loop=program)
+        self.assertFalse(body.create_program_calls)
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual(children, program.children)
+        self.assertIsNone(program.waveform)
+        self.assert_measurement_windows_equal({}, program.get_measurement_windows())
 
     def test_create_program_rep_count_zero_constant(self) -> None:
         repetitions = 0
@@ -208,11 +306,15 @@ class RepetitionPulseTemplateSequencingTests(unittest.TestCase):
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
 
-        program = t.create_program(parameters=parameters,
+        program = Loop(measurements=[])
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
         self.assertFalse(body.create_program_calls)
-        self.assertIsNone(program)
+        self.assertFalse(program.children)
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual([], program._measurements)
 
     def test_create_program_rep_count_zero_constant_with_measurement(self) -> None:
         repetitions = 0
@@ -227,14 +329,15 @@ class RepetitionPulseTemplateSequencingTests(unittest.TestCase):
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
 
-        program = t.create_program(parameters=parameters,
+        program = Loop(measurements=[])
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
         self.assertFalse(body.create_program_calls)
         self.assertFalse(program.children)
-        self.assertEqual(0, program.repetition_count)
-        self.assertEqual([('fire', 0, 7.1)], program._measurements)
-        self.assertEqual([{'fire': (0, 7.1)}], program.get_measurement_windows())
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual([], program._measurements)
 
     def test_create_program_rep_count_zero_declaration(self) -> None:
         repetitions = "foo"
@@ -249,11 +352,15 @@ class RepetitionPulseTemplateSequencingTests(unittest.TestCase):
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
 
-        program = t.create_program(parameters=parameters,
+        program = Loop(measurements=[])
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
         self.assertFalse(body.create_program_calls)
-        self.assertIsNone(program)
+        self.assertFalse(program.children)
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual([], program._measurements)
 
     def test_create_program_rep_count_zero_declaration_with_measurement(self) -> None:
         repetitions = "foo"
@@ -268,14 +375,15 @@ class RepetitionPulseTemplateSequencingTests(unittest.TestCase):
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
 
-        program = t.create_program(parameters=parameters,
+        program = Loop(measurements=[])
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
         self.assertFalse(body.create_program_calls)
         self.assertFalse(program.children)
-        self.assertEqual(0, program.repetition_count)
-        self.assertEqual([('fire', 0, 7.1)], program._measurements)
-        self.assertEqual([{'fire': (0, 7.1)}], program.get_measurement_windows())
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual([], program._measurements)
 
     def test_create_program_rep_count_neg_declaration(self) -> None:
         repetitions = "foo"
@@ -290,11 +398,15 @@ class RepetitionPulseTemplateSequencingTests(unittest.TestCase):
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
 
-        program = t.create_program(parameters=parameters,
+        program = Loop(measurements=[])
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
         self.assertFalse(body.create_program_calls)
-        self.assertIsNone(program)
+        self.assertFalse(program.children)
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual([], program._measurements)
 
     def test_create_program_rep_count_neg_declaration_with_measurements(self) -> None:
         repetitions = "foo"
@@ -309,47 +421,47 @@ class RepetitionPulseTemplateSequencingTests(unittest.TestCase):
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
 
-        program = t.create_program(parameters=parameters,
+        program = Loop(measurements=[])
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
         self.assertFalse(body.create_program_calls)
         self.assertFalse(program.children)
-        self.assertEqual(0, program.repetition_count)
-        self.assertEqual([('fire', 0, 7.1)], program._measurements)
-        self.assertEqual([{'fire': (0, 7.1)}], program.get_measurement_windows())
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual([], program._measurements)
 
     def test_create_program_none_subprogram(self) -> None:
         repetitions = "foo"
-        body_program = None
-        body = DummyPulseTemplate(duration=2.0, program=body_program)
+        body = DummyPulseTemplate(duration=0.0, waveform=None)
         t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'])
         parameters = dict(foo=ConstantParameter(3))
         measurement_mapping = dict(moth='fire')
         channel_mapping = dict(asd='f')
-        program = t.create_program(parameters=parameters,
+        program = Loop(measurements=[])
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
-
-        self.assertIsNone(program)
-        self.assertEqual((parameters, measurement_mapping, channel_mapping),
-                         body.create_program_calls[-1])
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
+        self.assertFalse(program.children)
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual([], program._measurements)
 
     def test_create_program_none_subprogram_with_measurement(self) -> None:
         repetitions = "foo"
-        body_program = None
-        body = DummyPulseTemplate(duration=2.0, program=body_program)
+        body = DummyPulseTemplate(duration=2.0, waveform=None, measurements=[('b', 2, 3)])
         t = RepetitionPulseTemplate(body, repetitions, parameter_constraints=['foo<9'], measurements=[('moth', 0, 'meas_end')])
         parameters = dict(foo=ConstantParameter(3), meas_end=ConstantParameter(7.1))
-        measurement_mapping = dict(moth='fire')
+        measurement_mapping = dict(moth='fire', b='b')
         channel_mapping = dict(asd='f')
-        program = t.create_program(parameters=parameters,
+        program = Loop(measurements=[])
+        t._internal_create_program(parameters=parameters,
                                    measurement_mapping=measurement_mapping,
-                                   channel_mapping=channel_mapping)
-
+                                   channel_mapping=channel_mapping,
+                                   parent_loop=program)
         self.assertFalse(program.children)
-        self.assertEqual(3, program.repetition_count) # 0 or 3, what is correct?
-        self.assertEqual([('fire', 0, 7.1)], program._measurements)
-        self.assertEqual({'fire': (0, 7.1)}, program.get_measurement_windows())
+        self.assertEqual(1, program.repetition_count)
+        self.assertEqual([], program._measurements)
 
 
 class RepetitionPulseTemplateOldSequencingTests(unittest.TestCase):


### PR DESCRIPTION
Implementations of new signature PT._internal_create_program for RepetitionPT, SequencePT, ForLoopPT, AtomicPT (and thus all subclasses of that) + tests.

MappingPT is the only one missing now.
After that is done, #287 should be finished.