### PR TITLE
Fix __matmul__ bug

### DIFF
--- a/qctoolkit/pulses/pulse_template.py
+++ b/qctoolkit/pulses/pulse_template.py
@@ -79,19 +79,14 @@ class PulseTemplate(Serializable, SequencingElement, metaclass=DocStringABCMeta)
     def __matmul__(self, other: Union['PulseTemplate', MappingTuple]) -> 'SequencePulseTemplate':
         """This method enables using the @-operator (intended for matrix multiplication) for
          concatenating pulses. If one of the pulses is a SequencePulseTemplate the other pulse gets merged into it"""
-
         from qctoolkit.pulses.sequence_pulse_template import SequencePulseTemplate
 
-        subtemplates = itertools.chain(self.subtemplates if isinstance(self, SequencePulseTemplate) else [self],
-                                       other.subtemplates if isinstance(other, SequencePulseTemplate) else [other])
-        return SequencePulseTemplate(*subtemplates)
+        return SequencePulseTemplate.concatenate(self, other)
 
     def __rmatmul__(self, other: MappingTuple) -> 'SequencePulseTemplate':
         from qctoolkit.pulses.sequence_pulse_template import SequencePulseTemplate
 
-        subtemplates = itertools.chain([other],
-                                       self.subtemplates if isinstance(self, SequencePulseTemplate) else [self])
-        return SequencePulseTemplate(*subtemplates)
+        return SequencePulseTemplate.concatenate(other, self)
 
     @property
     @abstractmethod

--- a/qctoolkit/pulses/sequence_pulse_template.py
+++ b/qctoolkit/pulses/sequence_pulse_template.py
@@ -85,6 +85,28 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
 
         self._register(registry=registry)
 
+    @classmethod
+    def concatenate(cls, *pulse_templates: Union[PulseTemplate, MappingTuple], **kwargs) -> 'SequencePulseTemplate':
+        """Sequences the given pulse templates by creating a SequencePulseTemplate. Pulse templates that are
+        SequencePulseTemplates and do not carry additional information (identifier, measurements, parameter constraints)
+        are not used directly but their sub templates are.
+        Args:
+            *pulse_templates: Pulse templates to concatenate
+            **kwargs: Forwarded to the __init__
+
+        Returns: Concatenated templates
+        """
+        parsed = []
+        for pt in pulse_templates:
+            if (isinstance(pt, SequencePulseTemplate)
+                    and pt.identifier is None
+                    and not pt.measurement_declarations
+                    and not pt.parameter_constraints):
+                parsed.extend(pt.subtemplates)
+            else:
+                parsed.append(pt)
+        return cls(*parsed, **kwargs)
+
     @property
     def parameter_names(self) -> Set[str]:
         return self.constrained_parameters.union(self.measurement_parameters, *(st.parameter_names for st in self.__subtemplates))
@@ -183,3 +205,5 @@ class SequencePulseTemplate(PulseTemplate, ParameterConstrainer, MeasurementDefi
             return {k: x[k] + y[k] for k in x}
 
         return functools.reduce(add_dicts, [sub.integral for sub in self.__subtemplates], expressions)
+
+

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 from typing import Optional, Dict, Set, Any
 
@@ -162,3 +163,24 @@ class AtomicPulseTemplateTests(unittest.TestCase):
 
         self.assertIsInstance(exec, EXECInstruction)
         self.assertEqual(exec.waveform.defined_channels, {'A'})
+
+
+class PulseTemplateTests(unittest.TestCase):
+    def test_matmul(self):
+        a = PulseTemplateStub()
+        b = PulseTemplateStub()
+
+        from qctoolkit.pulses.sequence_pulse_template import SequencePulseTemplate
+        with mock.patch.object(SequencePulseTemplate, 'concatenate', return_value='concat') as mock_concatenate:
+            self.assertEqual(a @ b, 'concat')
+            mock_concatenate.assert_called_once_with(a, b)
+
+    def test_rmatmul(self):
+        a = PulseTemplateStub()
+        b = (1, 2, 3)
+
+        from qctoolkit.pulses.sequence_pulse_template import SequencePulseTemplate
+        with mock.patch.object(SequencePulseTemplate, 'concatenate', return_value='concat') as mock_concatenate:
+            self.assertEqual(b @ a, 'concat')
+            mock_concatenate.assert_called_once_with(b, a)
+

--- a/tests/pulses/sequence_pulse_template_tests.py
+++ b/tests/pulses/sequence_pulse_template_tests.py
@@ -16,9 +16,7 @@ from tests.serialization_dummies import DummySerializer
 from tests.serialization_tests import SerializableTests
 
 
-
 class SequencePulseTemplateTest(unittest.TestCase):
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
@@ -116,6 +114,27 @@ class SequencePulseTemplateTest(unittest.TestCase):
         pulse = SequencePulseTemplate(dummy1, dummy2)
 
         self.assertEqual({'A': ExpressionScalar('k+2*b+7*(b-f)'), 'B': ExpressionScalar('0.24*f')}, pulse.integral)
+
+    def test_concatenate(self):
+        a = DummyPulseTemplate(parameter_names={'foo'}, defined_channels={'A'})
+        b = DummyPulseTemplate(parameter_names={'bar'}, defined_channels={'A'})
+
+        spt_anon = SequencePulseTemplate(a, b)
+        spt_id = SequencePulseTemplate(a, b, identifier='id')
+        spt_meas = SequencePulseTemplate(a, b, measurements=[('m', 0, 'd')])
+        spt_constr = SequencePulseTemplate(a, b, parameter_constraints=['a < b'])
+
+        merged = SequencePulseTemplate.concatenate(a, spt_anon, b)
+        self.assertEqual(merged.subtemplates, [a, a, b, b])
+
+        result = SequencePulseTemplate.concatenate(a, spt_id, b)
+        self.assertEqual(result.subtemplates, [a, spt_id, b])
+
+        result = SequencePulseTemplate.concatenate(a, spt_meas, b)
+        self.assertEqual(result.subtemplates, [a, spt_meas, b])
+
+        result = SequencePulseTemplate.concatenate(a, spt_constr, b)
+        self.assertEqual(result.subtemplates, [a, spt_constr, b])
 
 
 class SequencePulseTemplateSerializationTests(SerializableTests, unittest.TestCase):
@@ -308,69 +327,6 @@ class SequencePulseTemplateTestProperties(SequencePulseTemplateTest):
 
         self.assertEqual(spt.measurement_names, {'a', 'b', 'c'})
 
-
-class PulseTemplateConcatenationTest(unittest.TestCase):
-    def __init__(self,*args,**kwargs):
-        super().__init__(*args,**kwargs)
-
-    def test_concatenation_pulse_template(self):
-        a = DummyPulseTemplate(parameter_names={'foo'}, defined_channels={'A'})
-        b = DummyPulseTemplate(parameter_names={'bar'}, defined_channels={'A'})
-        c = DummyPulseTemplate(parameter_names={'snu'}, defined_channels={'A'})
-        d = (c, {'snu': 'bar'})
-
-        seq = a @ a
-        self.assertTrue(len(seq.subtemplates) == 2)
-        for st in seq.subtemplates:
-            self.assertEqual(st, a)
-
-        seq = a @ b
-        self.assertTrue(len(seq.subtemplates)==2)
-        for st, expected in zip(seq.subtemplates,[a, b]):
-            self.assertTrue(st, expected)
-
-        seq = a @ b @ c
-        self.assertTrue(len(seq.subtemplates) == 3)
-        for st, expected in zip(seq.subtemplates, [a, b, c]):
-            self.assertTrue(st, expected)
-
-        seq = a @ d
-        self.assertTrue(len(seq.subtemplates) == 2)
-        self.assertIs(seq.subtemplates[0], a)
-        self.assertIsInstance(seq.subtemplates[1], MappingPulseTemplate)
-        self.assertIs(seq.subtemplates[1].template, c)
-
-        seq = d @ a
-        self.assertTrue(len(seq.subtemplates) == 2)
-        self.assertIs(seq.subtemplates[1], a)
-        self.assertIsInstance(seq.subtemplates[0], MappingPulseTemplate)
-        self.assertIs(seq.subtemplates[0].template, c)
-
-    def test_concatenation_sequence_table_pulse(self):
-        a = DummyPulseTemplate(parameter_names={'foo'}, defined_channels={'A'})
-        b = DummyPulseTemplate(parameter_names={'bar'}, defined_channels={'A'})
-        c = DummyPulseTemplate(parameter_names={'snu'}, defined_channels={'A'})
-        d = DummyPulseTemplate(parameter_names={'snu'}, defined_channels={'A'})
-
-        seq1 = SequencePulseTemplate(a, b)
-        self.assertEqual({'foo', 'bar'}, seq1.parameter_names)
-        seq2 = SequencePulseTemplate(c, d)
-        self.assertEqual({'snu'}, seq2.parameter_names)
-
-        seq = seq1 @ c
-        self.assertTrue(len(seq.subtemplates) == 3)
-        for st, expected in zip(seq.subtemplates,[a, b, c]):
-            self.assertTrue(st, expected)
-
-        seq = c @ seq1
-        self.assertTrue(len(seq.subtemplates) == 3)
-        for st, expected in zip(seq.subtemplates, [c, a, b]):
-            self.assertTrue(st, expected)
-
-        seq = seq1 @ seq2
-        self.assertTrue(len(seq.subtemplates) == 4)
-        for st, expected in zip(seq.subtemplates, [a, b, c, d]):
-            self.assertTrue(st, expected)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Currently `__matmul__` drops measurements, identifiers and parameter constraints of SequencePulseTemplates that are concatenated with it.

This is fixed here.