### PR TITLE
Some "fixes" for serialization.

### DIFF
--- a/qctoolkit/serialization.py
+++ b/qctoolkit/serialization.py
@@ -367,18 +367,18 @@ def new_default_pulse_registry() -> None:
 class Serializable(metaclass=SerializableMeta):
     """Any object that can be converted into a serialized representation for storage and back.
 
-    Serializable is the interface used by Serializer to obtain representations of objects that
+    Serializable is the interface used by PulseStorage to obtain representations of objects that
     need to be stored. It essentially provides the methods get_serialization_data, which returns
     a dictionary which contains all relevant properties of the Serializable object encoded as
     basic Python types, and deserialize, which is able to reconstruct the object from given
     such a dictionary.
 
     Additionally, a Serializable object MAY have a unique identifier, which indicates towards
-    the Serializer that this object should be stored as a separate data item and accessed by
+    the PulseStorage that this object should be stored as a separate data item and accessed by
     reference instead of possibly embedding it into a containing Serializable's representation.
 
     See also:
-        Serializer
+        PulseStorage
     """
 
     type_identifier_name = '#type'
@@ -432,7 +432,7 @@ class Serializable(metaclass=SerializableMeta):
         """Return all data relevant for serialization as a dictionary containing only base types.
 
         Implementation hint:
-        In the old serialization routines, if the Serializer contains complex objects which are itself
+        In the old serialization routines, if the Serializable contains complex objects which are itself
         Serializables, a serialized representation for these MUST be obtained by calling the dictify()
         method of serializer. The reason is that serializer may decide to either return a dictionary
         to embed or only a reference to the Serializable subelement. This is DEPRECATED behavior as of May 2018.
@@ -472,12 +472,13 @@ class Serializable(metaclass=SerializableMeta):
             For greater clarity, implementations of this method should be precise in their return value,
             i.e., give their exact class name, and also replace the **kwargs argument by a list of
             arguments required, i.e., those returned by get_serialization_data.
-            If this Serializable contains complex objects which are itself of type Serializable, their
-            dictionary representations MUST be converted into objects using serializers deserialize()
-            method when using the old serialization routines. This is DEPRECATED behavior.
-            Using the new routines a serializable is only responsible to decode it's own dictionary,
+            Using old serialization routines, if this Serializable contains complex objects which are itself
+            of type Serializable, their dictionary representations MUST be converted into objects using
+            serializers deserialize() method. This is DEPRECATED behavior.
+            Using the new routines, a serializable is only responsible to decode it's own dictionary,
             not those of nested objects (i.e., all incoming arguments are already processed by the
-            serialization routines). For the transition time where both implementations are
+            serialization routines).
+            For the transition time where both variants are
             available, implementations of this method should support the old and new routines, using
             the presence of the serializer argument to differentiate between both. For the new routines,
             just call this base class function.

--- a/tests/pulses/pulse_template_tests.py
+++ b/tests/pulses/pulse_template_tests.py
@@ -44,8 +44,8 @@ class PulseTemplateStub(PulseTemplate):
     def get_serialization_data(self, serializer: Optional['Serializer']=None) -> Dict[str, Any]:
         raise NotImplementedError()
 
-    @staticmethod
-    def deserialize(serializer: Optional['Serializer']=None, **kwargs) -> 'AtomicPulseTemplateStub':
+    @classmethod
+    def deserialize(cls, serializer: Optional['Serializer']=None, **kwargs) -> 'AtomicPulseTemplateStub':
         raise NotImplementedError()
 
     @property

--- a/tests/serialization_tests.py
+++ b/tests/serialization_tests.py
@@ -723,7 +723,7 @@ class PulseStorageTests(unittest.TestCase):
     def test_write_through(self):
         instance_1 = DummySerializable(identifier='my_id_1', registry=dict())
         inner_instance = DummySerializable(identifier='my_id_2', registry=dict())
-        outer_instance = NestedDummySerializable(inner_instance, identifier='my_id_3', registry=dict())
+        outer_instance = DummySerializable(inner=inner_instance, identifier='my_id_3', registry=dict())
 
         def get_expected():
             return {identifier: serialized
@@ -737,7 +737,7 @@ class PulseStorageTests(unittest.TestCase):
     def test_write_through_does_not_overwrite_subpulses(self) -> None:
         previous_inner = DummySerializable(identifier='my_id_1', data='hey', registry=dict())
         inner_instance = DummySerializable(identifier='my_id_1', data='ho', registry=dict())
-        outer_instance = NestedDummySerializable(inner_instance, identifier='my_id_2', registry=dict())
+        outer_instance = DummySerializable(inner=inner_instance, identifier='my_id_2', registry=dict())
 
         self.storage['my_id_1'] = previous_inner
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
- Updated docstring of Serializable to refer to PulseStorage instead of Serializer.
- Found a remaining deserialize which was stall a staticmethod instead of a classmethod in PulseTemplateStub testing code.
- Replaced references of NestedDummySerializable in tests for new serialization routines by simple DummySerializble (this will allow us to get rid of NestedDummySerializable once we ditch the old serialization routines + tests).