### PR TITLE
Included pulses.pulse_template_parameter_mapping in pulses.__init__.py

### DIFF
--- a/qctoolkit/pulses/__init__.py
+++ b/qctoolkit/pulses/__init__.py
@@ -10,6 +10,12 @@ from qctoolkit.pulses.sequence_pulse_template import SequencePulseTemplate as Se
 from qctoolkit.pulses.table_pulse_template import TablePulseTemplate as TablePT
 from qctoolkit.pulses.point_pulse_template import PointPulseTemplate as PointPT
 
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    # ensure this is included.. it adds a deserialization handler for pulse_template_parameter_mapping.MappingPT which is not present otherwise
+    import qctoolkit.pulses.pulse_template_parameter_mapping
+
 from qctoolkit.pulses.sequencing import Sequencer
 
 __all__ = ["FunctionPT", "ForLoopPT", "AtomicMultiChannelPT", "MappingPT", "RepetitionPT", "SequencePT", "TablePT",

--- a/tests/pulses/pulse_template_parameter_mapping_tests.py
+++ b/tests/pulses/pulse_template_parameter_mapping_tests.py
@@ -15,7 +15,6 @@ class TestPulseTemplateParameterMappingFileTests(unittest.TestCase):
             from qctoolkit.pulses.pulse_template_parameter_mapping import MappingPulseTemplate
             dummy_t = DummyPulseTemplate()
             map_t = MappingPulseTemplate(dummy_t)
-            serializer = Serializer(DummyStorageBackend())
-            type_str = serializer.get_type_identifier(map_t)
+            type_str = map_t.get_type_identifier()
             self.assertEqual("qctoolkit.pulses.mapping_pulse_template.MappingPulseTemplate", type_str)
 


### PR DESCRIPTION
pusle_template_parameter_mapping adds a deserialization handler for MappingPTs in outdated serializations which must be present for their deserialization to succeed.
Additionally: removed reference to Serializer in a corresponding test.