### PR TITLE
Compatibility Tests for create_program

### DIFF
--- a/qctoolkit/_program/_loop.py
+++ b/qctoolkit/_program/_loop.py
@@ -44,7 +44,7 @@ class Loop(Comparable, Node):
 
     @property
     def compare_key(self) -> Tuple:
-        return self._waveform, self.repetition_count, tuple(c.compare_key for c in self)
+        return self._waveform, self.repetition_count, self._measurements, tuple(c.compare_key for c in self)
 
     def append_child(self, loop: Optional['Loop']=None, **kwargs) -> None:
         # do not invalidate but update cached duration

--- a/qctoolkit/pulses/pulse_template.py
+++ b/qctoolkit/pulses/pulse_template.py
@@ -197,6 +197,10 @@ class AtomicPulseTemplate(PulseTemplate, MeasurementDefiner):
                                  measurement_mapping: Dict[str, Optional[str]],
                                  channel_mapping: Dict[ChannelID, Optional[ChannelID]],
                                  parent_loop: Loop) -> None:
+        ### current behavior (same as previously): only adds EXEC Loop and measurements if a waveform exists.
+        ### measurements are directly added to parent_loop (to reflect behavior of Sequencer + MultiChannelProgram)
+        # todo (2018-08-08): could move measurements into own Loop object?
+
         # todo (2018-07-05): why are parameter constraints not validated here?
         try:
             parameters = {parameter_name: parameters[parameter_name].get_value()
@@ -211,8 +215,8 @@ class AtomicPulseTemplate(PulseTemplate, MeasurementDefiner):
         waveform = self.build_waveform(parameters,
                                        channel_mapping=channel_mapping)
         if waveform:
-            parent_loop.append_child(waveform=waveform, measurements=measurements)
-
+            parent_loop.add_measurements(measurements=measurements)
+            parent_loop.append_child(waveform=waveform)
 
     @abstractmethod
     def build_waveform(self,

--- a/tests/pulses/mapping_pulse_template_tests.py
+++ b/tests/pulses/mapping_pulse_template_tests.py
@@ -8,6 +8,9 @@ from qctoolkit.pulses.parameters import ConstantParameter, ParameterConstraintVi
 from qctoolkit.expressions import Expression
 from qctoolkit._program._loop import Loop
 
+from qctoolkit._program._loop import MultiChannelProgram
+from qctoolkit.pulses.sequencing import Sequencer
+
 from tests.pulses.sequencing_dummies import DummyPulseTemplate, DummySequencer, DummyInstructionBlock, MeasurementWindowTestCase, DummyWaveform
 from tests.serialization_tests import SerializableTests
 from tests.serialization_dummies import DummySerializer
@@ -228,6 +231,14 @@ class MappingPulseTemplateSequencingTest(MeasurementWindowTestCase):
         self.assertIs(template.waveform, program.children[0].waveform)
         self.assert_measurement_windows_equal({'meas3': ([0], [1])}, program.get_measurement_windows())
 
+        # ensure same result as from Sequencer
+        sequencer = Sequencer()
+        sequencer.push(st, parameters=pre_parameters, conditions={}, window_mapping=pre_measurement_mapping,
+                       channel_mapping=pre_channel_mapping)
+        block = sequencer.build()
+        program_old = MultiChannelProgram(block, channels={'A'}).programs[frozenset({'A'})]
+        self.assertEqual(program_old, program)
+
     def test_create_program_invalid_measurement_mapping(self) -> None:
         measurement_mapping = {'meas1': 'meas2'}
         parameter_mapping = {'t': 'k'}
@@ -334,6 +345,14 @@ class MappingPulseTemplateSequencingTest(MeasurementWindowTestCase):
         self.assertEqual(1, program.repetition_count)
         self.assertEqual(0, len(program.children))
         self.assertIsNone(program._measurements)
+
+        # ensure same result as from Sequencer
+        sequencer = Sequencer()
+        sequencer.push(st, parameters=pre_parameters, conditions={}, window_mapping=pre_measurement_mapping,
+                       channel_mapping=pre_channel_mapping)
+        block = sequencer.build()
+        program_old = MultiChannelProgram(block, channels={'A'}).programs[frozenset({'A'})]
+        self.assertEqual(program_old, program)
 
 
 class MappingPulseTemplateOldSequencingTests(unittest.TestCase):

--- a/tests/pulses/sequencing_dummies.py
+++ b/tests/pulses/sequencing_dummies.py
@@ -366,6 +366,10 @@ class DummyPulseTemplate(AtomicPulseTemplate):
                        channel_mapping: Dict['ChannelID', 'ChannelID'],
                        instruction_block: InstructionBlock):
         self.build_sequence_arguments.append((sequencer,parameters,conditions, measurement_mapping, channel_mapping, instruction_block))
+        measurements = self.get_measurement_windows(parameters, measurement_mapping)
+        if self.waveform:
+            instruction_block.add_instruction_meas(measurements)
+            instruction_block.add_instruction_exec(waveform=self.waveform)
 
     # def create_program(self, *,
     #                    parameters: Dict[str, Parameter],
@@ -382,9 +386,11 @@ class DummyPulseTemplate(AtomicPulseTemplate):
         measurements = self.get_measurement_windows(parameters, measurement_mapping)
         self.create_program_calls.append((parameters, measurement_mapping, channel_mapping, parent_loop))
         if self._program:
-            parent_loop.append_child(waveform=self._program.waveform, children=self._program.children, measurements=measurements)
+            parent_loop.add_measurements(measurements)
+            parent_loop.append_child(waveform=self._program.waveform, children=self._program.children)
         elif self.waveform:
-            parent_loop.append_child(waveform=self.waveform, measurements=measurements)
+            parent_loop.add_measurements(measurements)
+            parent_loop.append_child(waveform=self.waveform)
 
     def build_waveform(self,
                        parameters: Dict[str, Parameter],


### PR DESCRIPTION
Extended tests for _internal_create_program to check that the result is the same as doing old Sequencing and constructing MultiChannelProgram from the resulting InstructionBlock.

Fixed behavior of AtomicPulseTemplate (and DummyPulseTemplate). Added measurements to compare_key of Loop.

Differences in behavior as detected by those tests are the following:

AtomicPulseTemplate (and thus all subclasses (TablePT, PointPT, MutliChannelPT, FunctionPT)):
- behavior exactly the same

SequencePulseTemplate:
- if all subtemplates have no duration (i.e. duration of the SequencePT is 0), _internal_create_program adds nothing (no children, no waveform, no measurements) to the parent_loop. Sequencer+MCP results in empty loop with measurements from SequencePT.

RepetitionPulseTemplate:
- if repetition count is zero or negative and a measurement was defined in RepetitionPT: Sequencer+MCP return an empty Loop with measurement, _internal_create_program does not modify the given parent_loop (does not add measurement)
- if the body template has duration zero: Sequencer+MCP return an empty loop with repetition count as specified by the RepetitionPT, _interal_create_program does not modify the given parent_loop (repetition count unchanged)
- if the body template has duration zero and a measurement was defined in RepetitionPT: Sequencer+MCP return an empty loop with repetition count as specified by the RepetitionPT and measurements, _interal_create_program does not modify the given parent_loop (repetition count unchanged and no measurements)
- if the RepitionPT does not have siblings in the pulse template tree and the subtemplate specifies only a waveform: Sequencer+MCP return a single Loop object holding the waveform with the repetition count specified by RepetitionPT, _internal_create_program creates a nested Loop structure (as in all other cases) [optimization in MCP in lines 347-360]

MappingPulseTemplate:
- behavior exactly the same

ForLoopPulseTemplate:
- if the body template has duration zero and a measurement was defined in ForLoopPT: Sequencer+MCP return an empty loop with measurements, _internal_create_program does not modify the parent_loop object (does not add measurements)

Differences in dealing with measurements were expected.

The optimization for RepetitionPT should not be done in _internal_create_program but during a subsequent optimization/hardware adaption step imo.

Setting the repetition count for empty loops should be a non-issue as well.

Your thoughts, @terrorfisch ?