### PR TITLE
Fixed a bug in SequenceWaveform.unsafe_sample() which could cause a crash

### DIFF
--- a/qctoolkit/_program/waveforms.py
+++ b/qctoolkit/_program/waveforms.py
@@ -318,7 +318,7 @@ class SequenceWaveform(Waveform):
 
             indices = slice(*np.searchsorted(sample_times, (float(time), float(end)), 'left'))
             subwaveform.unsafe_sample(channel=channel,
-                                      sample_times=sample_times[indices]-time,
+                                      sample_times=sample_times[indices]-np.float64(time),
                                       output_array=output_array[indices])
             time = end
         return output_array

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,6 @@
+import matplotlib
+matplotlib.use('Agg')
+
 __all__ = [
     'pulses',
     'qcmatlab',
@@ -7,6 +10,5 @@ __all__ = [
     'pyflakes_syntax_tests',
     'serialization_dummies',
     'serialization_tests',
-    'coverage_tests',
     'backward_compatibility'
 ]

--- a/tests/_program/waveforms_tests.py
+++ b/tests/_program/waveforms_tests.py
@@ -286,6 +286,23 @@ class SequenceWaveformTest(unittest.TestCase):
 
         self.assertEqual(len(swf2.compare_key), 3)
 
+    def test_sample_times_type(self) -> None:
+        with mock.patch.object(DummyWaveform, 'unsafe_sample') as unsafe_sample_patch:
+            dwfs = (DummyWaveform(duration=1.),
+                    DummyWaveform(duration=3.),
+                    DummyWaveform(duration=2.))
+
+            swf = SequenceWaveform(dwfs)
+
+            sample_times = np.arange(0, 60) * 0.1
+            expected_output = np.concatenate((sample_times[:10], sample_times[10:40] - 1, sample_times[40:] - 4))
+            expected_inputs = sample_times[0:10], sample_times[10:40] - 1, sample_times[40:] - 4
+
+            swf.unsafe_sample('A', sample_times=sample_times)
+            inputs = [call_args[1]['sample_times'] for call_args in unsafe_sample_patch.call_args_list] # type: List[np.ndarray]
+            np.testing.assert_equal(expected_inputs, inputs)
+            self.assertEqual([input.dtype for input in inputs], [np.float64 for _ in inputs])
+
     def test_unsafe_sample(self):
         dwfs = (DummyWaveform(duration=1.),
                 DummyWaveform(duration=3.),

--- a/tests/pulses/bug_tests.py
+++ b/tests/pulses/bug_tests.py
@@ -1,0 +1,49 @@
+import unittest
+
+from qctoolkit.pulses.table_pulse_template import TablePulseTemplate
+from qctoolkit.pulses.function_pulse_template import FunctionPulseTemplate
+from qctoolkit.pulses.sequence_pulse_template import SequencePulseTemplate
+from qctoolkit.pulses.repetition_pulse_template import RepetitionPulseTemplate
+from qctoolkit.pulses.multi_channel_pulse_template import AtomicMultiChannelPulseTemplate
+
+from qctoolkit.pulses.plotting import plot
+
+
+class BugTests(unittest.TestCase):
+
+    def test_plotting_two_channel_function_pulse_after_two_channel_table_pulse_crash(self) -> None:
+        """ successful if no crash -> no asserts """
+        template = TablePulseTemplate(entries={'A': [(0, 0),
+                                          ('ta', 'va', 'hold'),
+                                          ('tb', 'vb', 'linear'),
+                                          ('tend', 0, 'jump')],
+                                    'B': [(0, 0),
+                                          ('ta', '-va', 'hold'),
+                                          ('tb', '-vb', 'linear'),
+                                          ('tend', 0, 'jump')]}, measurements=[('m', 0, 'ta'),
+                                                                               ('n', 'tb', 'tend-tb')])
+
+        parameters = {'ta': 2,
+                      'va': 2,
+                      'tb': 4,
+                      'vb': 3,
+                      'tc': 5,
+                      'td': 11,
+                      'tend': 6}
+        _ = plot(template, parameters, sample_rate=100, show=False, plot_measurements={'m', 'n'})
+
+        repeated_template = RepetitionPulseTemplate(template, 'n_rep')
+        sine_template = FunctionPulseTemplate('sin_a*sin(t)', '2*3.1415')
+        two_channel_sine_template = AtomicMultiChannelPulseTemplate(
+            (sine_template, {'default': 'A'}),
+            (sine_template, {'default': 'B'}, {'sin_a': 'sin_b'})
+        )
+        sequence_template = SequencePulseTemplate(repeated_template, two_channel_sine_template)
+        #sequence_template = SequencePulseTemplate(two_channel_sine_template, repeated_template) # this was working fine
+
+        sequence_parameters = dict(parameters)  # we just copy our parameter dict from before
+        sequence_parameters['n_rep'] = 4  # and add a few new values for the new params from the sine wave
+        sequence_parameters['sin_a'] = 1
+        sequence_parameters['sin_b'] = 2
+
+        _ = plot(sequence_template, parameters=sequence_parameters, sample_rate=100, show=False)


### PR DESCRIPTION
For all sub-waveform except the first one the sample_times numpy array had dtype=object instead of dtype=float64 which led to a crash applying lambdas resulting from sympy.lambdify (e.g. when sampling FunctionWaveforms).

Added a specific test case to ensure the problem does not occur again. Also added the whole initial sample code that first encountered the bug in a new test file tests/pulses/bug_tests.py now intended to collect all reported bugs.

-- lumip